### PR TITLE
Add Commit to IPAConfig

### DIFF
--- a/ipa/config.go
+++ b/ipa/config.go
@@ -69,9 +69,15 @@ func slowMultiScalar(points []bandersnatch.PointAffine, scalars []fr.Element) ba
 	return result
 }
 
+// Commits to a polynomial using the SRS
+// panics if the length of the SRS does not equal the number of polynomial coefficients
+func (ic *IPAConfig) Commit(polynomial []fr.Element) bandersnatch.PointAffine {
+	return commit(ic.SRS, polynomial)
+}
+
 // Commits to a polynomial using the input group elements
 // panics if the number of group elements does not equal the number of polynomial coefficients
-func Commit(group_elements []bandersnatch.PointAffine, polynomial []fr.Element) bandersnatch.PointAffine {
+func commit(group_elements []bandersnatch.PointAffine, polynomial []fr.Element) bandersnatch.PointAffine {
 	if len(group_elements) != len(polynomial) {
 		panic(fmt.Sprintf("diff sizes, %d != %d", len(group_elements), len(polynomial)))
 	}

--- a/ipa/ipa_test.go
+++ b/ipa/ipa_test.go
@@ -18,7 +18,7 @@ func TestIPAProofCreateVerify(t *testing.T) {
 
 	// Prover view
 	poly := test_helper.TestPoly256(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
-	prover_comm := Commit(ipaConf.SRS, poly)
+	prover_comm := ipaConf.Commit(poly)
 
 	prover_transcript := common.NewTranscript("ipa")
 
@@ -81,7 +81,7 @@ func TestBasicCommit(t *testing.T) {
 		}
 		a = append(a, tmp)
 	}
-	got := Commit(generators, a)
+	got := commit(generators, a)
 
 	total := fr.Zero()
 	for i := 0; i < 5; i++ {

--- a/ipa/prover.go
+++ b/ipa/prover.go
@@ -42,11 +42,11 @@ func CreateIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment ban
 		z_L := InnerProd(a_R, b_L)
 		z_R := InnerProd(a_L, b_R)
 
-		C_L_1 := Commit(G_L, a_R)
-		C_L := Commit([]bandersnatch.PointAffine{C_L_1, q}, []fr.Element{fr.One(), z_L})
+		C_L_1 := commit(G_L, a_R)
+		C_L := commit([]bandersnatch.PointAffine{C_L_1, q}, []fr.Element{fr.One(), z_L})
 
-		C_R_1 := Commit(G_R, a_L)
-		C_R := Commit([]bandersnatch.PointAffine{C_R_1, q}, []fr.Element{fr.One(), z_R})
+		C_R_1 := commit(G_R, a_L)
+		C_R := commit([]bandersnatch.PointAffine{C_R_1, q}, []fr.Element{fr.One(), z_R})
 
 		L[i] = C_L
 		R[i] = C_R

--- a/ipa/verifier.go
+++ b/ipa/verifier.go
@@ -42,7 +42,7 @@ func CheckIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment band
 
 		challenges_inv[i] = xInv
 
-		commitment = Commit([]bandersnatch.PointAffine{commitment, L, R}, []fr.Element{fr.One(), x, xInv})
+		commitment = commit([]bandersnatch.PointAffine{commitment, L, R}, []fr.Element{fr.One(), x, xInv})
 	}
 
 	current_basis := ic.SRS

--- a/multiproof.go
+++ b/multiproof.go
@@ -60,7 +60,7 @@ func CreateMultiProof(transcript *common.Transcript, ipaConf *ipa.IPAConfig, Cs 
 		}
 	}
 
-	D := ipa.Commit(ipaConf.SRS, g_x)
+	D := ipaConf.Commit(g_x)
 
 	transcript.AppendScalar(&r)
 	transcript.AppendPoint(&D)
@@ -92,7 +92,7 @@ func CreateMultiProof(transcript *common.Transcript, ipaConf *ipa.IPAConfig, Cs 
 		h_minus_g[i].Sub(&h_x[i], &g_x[i])
 	}
 
-	E := ipa.Commit(ipaConf.SRS, h_x)
+	E := ipaConf.Commit(h_x)
 
 	var E_minus_D bandersnatch.PointAffine
 

--- a/multiproof_test.go
+++ b/multiproof_test.go
@@ -19,7 +19,7 @@ func TestMultiProofCreateVerify(t *testing.T) {
 	// Prover view
 	poly_1 := test_helper.TestPoly256(1, 1, 1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
 	prover_transcript := common.NewTranscript("multiproof")
-	prover_comm_1 := ipa.Commit(ipaConf.SRS, poly_1)
+	prover_comm_1 := ipaConf.Commit(poly_1)
 
 	zero := fr.Zero()
 	one := fr.One()


### PR DESCRIPTION
- committing to a polynomial using an arbitrary set of generators is only needed internally, so we can make that function private and add a Commit method on IPAConfig, which allows you to commit to a polynomial using the SRS in the config