### PR TITLE
add (de)serialization methods to the precomputation tables

### DIFF
--- a/ipa/config.go
+++ b/ipa/config.go
@@ -29,7 +29,7 @@ type IPAConfig struct {
 	num_ipa_rounds uint32
 
 	// Precomputed SRS points
-	precomp_lag *bandersnatch.PrecomputeLagrange
+	PrecompLag *bandersnatch.PrecomputeLagrange
 }
 
 // This function creates 256 random generator points where the relative discrete log is
@@ -43,7 +43,7 @@ func NewIPASettings() *IPAConfig {
 		Q:                  Q,
 		PrecomputedWeights: NewPrecomputedWeights(),
 		num_ipa_rounds:     compute_num_rounds(common.POLY_DEGREE),
-		precomp_lag:        bandersnatch.NewPrecomputeLagrange(srs),
+		PrecompLag:         bandersnatch.NewPrecomputeLagrange(srs),
 	}
 }
 
@@ -64,7 +64,7 @@ func multiScalar(points []bandersnatch.PointAffine, scalars []fr.Element) bander
 // Commits to a polynomial using the SRS
 // panics if the length of the SRS does not equal the number of polynomial coefficients
 func (ic *IPAConfig) Commit(polynomial []fr.Element) bandersnatch.PointAffine {
-	return *ic.precomp_lag.Commit(polynomial)
+	return *ic.PrecompLag.Commit(polynomial)
 }
 
 // Commits to a polynomial using the input group elements

--- a/ipa/ipa_test.go
+++ b/ipa/ipa_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"reflect"
 	"testing"
 
 	"github.com/crate-crypto/go-ipa/bandersnatch"
@@ -235,4 +236,21 @@ func removeDuplicatePoints(intSlice []bandersnatch.PointAffine) []bandersnatch.P
 		}
 	}
 	return list
+}
+
+func TestPrecompSerde(t *testing.T) {
+	points := GenerateRandomPoints(2)
+	pcl := bandersnatch.NewPrecomputeLagrange(points)
+	ser, err := pcl.SerializePrecomputedLagrange()
+	if err != nil {
+		t.Fatal(err)
+	}
+	deser, err := bandersnatch.DeserializePrecomputedLagrange(ser)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(pcl, deser) {
+		t.Fatalf("error during (de)serialization of precomputed data %v %v", pcl, deser)
+	}
 }


### PR DESCRIPTION
Generating the precomputation tables for the Lagrange points takes a lot of time. This causes geth to be seemingly idle for 2 to 5 minutes, giving the impression that a problem occurred. This is true, even if the verkle tree isn't activated in geth. This is a show-stopper for merging the geth PR.

As a mitigation strategy, I'd like to be able to generate it only once, and then store that data to the database, to be reloaded later. This PR therefore adds a `DeserializePrecomputedLagrange` function, that can be used to load said precomputed points from the database.

**Trigger Warning**: contains AmericaniZed (AmericaniZee?) spelling.