### PR TITLE
Avoid allocs improving ~15% performance and using ~97% less memory

### DIFF
--- a/bandersnatch/multiexp.go
+++ b/bandersnatch/multiexp.go
@@ -478,10 +478,6 @@ func (p *PointProj) msmC4(points []PointAffine, scalars []fr.Element, splitFirst
 	// critical for performance
 
 	// each go routine sends its result in chChunks[i] channel
-	//var chChunks [nbChunks]chan PointProj
-	//for i := 0; i < len(chChunks); i++ {
-	//chChunks[i] = make(chan PointProj, 1)
-	//}
 	var chChunks [nbChunks]PointProj
 	processChunk := func(j int, points []PointAffine, scalars []fr.Element, pointProj *PointProj) {
 		var buckets [1 << (c - 1)]PointProj

--- a/bandersnatch/point.go
+++ b/bandersnatch/point.go
@@ -216,19 +216,17 @@ func NewPointAffine(x, y fp.Element) PointAffine {
 // IsOnCurve checks if a point is on the twisted Edwards curve
 func (p *PointAffine) IsOnCurve() bool {
 
-	ecurve := GetEdwardsCurve()
-
 	var lhs, rhs, tmp fp.Element
 
 	tmp.Mul(&p.Y, &p.Y)
 	lhs.Mul(&p.X, &p.X).
-		Mul(&lhs, &ecurve.A).
+		Mul(&lhs, &edwards.A).
 		Add(&lhs, &tmp)
 
 	tmp.Mul(&p.X, &p.X).
 		Mul(&tmp, &p.Y).
 		Mul(&tmp, &p.Y).
-		Mul(&tmp, &ecurve.D)
+		Mul(&tmp, &edwards.D)
 	rhs.SetOne().Add(&rhs, &tmp)
 
 	return lhs.Equal(&rhs)
@@ -238,19 +236,17 @@ func (p *PointAffine) IsOnCurve() bool {
 // modifies p
 func (p *PointAffine) Add(p1, p2 *PointAffine) *PointAffine {
 
-	ecurve := GetEdwardsCurve()
-
 	var xu, yv, xv, yu, dxyuv, one, denx, deny fp.Element
 	pRes := new(PointAffine)
 	xv.Mul(&p1.X, &p2.Y)
 	yu.Mul(&p1.Y, &p2.X)
 	pRes.X.Add(&xv, &yu)
 
-	xu.Mul(&p1.X, &p2.X).Mul(&xu, &ecurve.A)
+	xu.Mul(&p1.X, &p2.X).Mul(&xu, &edwards.A)
 	yv.Mul(&p1.Y, &p2.Y)
 	pRes.Y.Sub(&yv, &xu)
 
-	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &ecurve.D)
+	dxyuv.Mul(&xv, &yu).Mul(&dxyuv, &edwards.D)
 	one.SetOne()
 	denx.Add(&one, &dxyuv)
 	deny.Sub(&one, &dxyuv)
@@ -302,14 +298,12 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 
 	var res PointProj
 
-	ecurve := GetEdwardsCurve()
-
 	var A, B, C, D, E, F, G, H, I fp.Element
 	A.Mul(&p1.Z, &p2.Z)
 	B.Square(&A)
 	C.Mul(&p1.X, &p2.X)
 	D.Mul(&p1.Y, &p2.Y)
-	E.Mul(&ecurve.D, &C).Mul(&E, &D)
+	E.Mul(&edwards.D, &C).Mul(&E, &D)
 	F.Sub(&B, &E)
 	G.Add(&B, &E)
 	H.Add(&p1.X, &p1.Y)
@@ -319,7 +313,7 @@ func (p *PointProj) Add(p1, p2 *PointProj) *PointProj {
 		Sub(&res.X, &D).
 		Mul(&res.X, &A).
 		Mul(&res.X, &F)
-	H.Mul(&ecurve.A, &C)
+	H.Mul(&edwards.A, &C)
 	res.Y.Sub(&D, &H).
 		Mul(&res.Y, &A).
 		Mul(&res.Y, &G)
@@ -335,14 +329,12 @@ func (p *PointProj) Double(p1 *PointProj) *PointProj {
 
 	var res PointProj
 
-	ecurve := GetEdwardsCurve()
-
 	var B, C, D, E, F, H, J, tmp fp.Element
 
 	B.Add(&p1.X, &p1.Y).Square(&B)
 	C.Square(&p1.X)
 	D.Square(&p1.Y)
-	E.Mul(&ecurve.A, &C)
+	E.Mul(&edwards.A, &C)
 	F.Add(&E, &D)
 	H.Square(&p1.Z)
 	tmp.Double(&H)
@@ -449,16 +441,13 @@ func GetPointFromX(x *fp.Element, choose_largest bool) *PointAffine {
 // ax^2 - 1 / (dx^2 - 1) = y^2
 func computeY(x *fp.Element, choose_largest bool) *fp.Element {
 
-	var D = GetEdwardsCurve().D
-	var A = GetEdwardsCurve().A
-
 	var one, num, den, y fp.Element
 	one.SetOne()
 	num.Square(x)       // x^2
-	den.Mul(&num, &D)   //dx^2
+	den.Mul(&num, &edwards.D)   //dx^2
 	den.Sub(&den, &one) //dx^2 - 1
 
-	num.Mul(&num, &A)   // ax^2
+	num.Mul(&num, &edwards.A)   // ax^2
 	num.Sub(&num, &one) // ax^2 - 1
 	y.Div(&num, &den)
 	is_nil := y.Sqrt(&y)

--- a/bandersnatch/point.go
+++ b/bandersnatch/point.go
@@ -104,17 +104,16 @@ func (p *PointAffine) SetBytes(buf []byte) (int, error) {
 
 // Reads an uncompressed affine point
 // Point is not guaranteed to be in the prime subgroup 
-func ReadUncompressedPoint(r io.Reader) *PointAffine {
-	var x = make([]byte, 32)
-	var y = make([]byte, 32)
-	n, err := r.Read(x)
+func ReadUncompressedPoint(r io.Reader) PointAffine {
+	var xy = make([]byte, 64)
+	n, err := r.Read(xy[:32])
 	if err != nil {
 		panic("error reading bytes")
 	}
 	if n != 32 {
 		panic("did not read enough bytes")
 	}
-	n, err = r.Read(y)
+	n, err = r.Read(xy[32:])
 	if err != nil {
 		panic("error reading bytes")
 	}
@@ -123,16 +122,14 @@ func ReadUncompressedPoint(r io.Reader) *PointAffine {
 	}
 
 	var x_fp = fp.Element{}
-	x_fp.SetBytes(x)
+	x_fp.SetBytes(xy[:32])
 	var y_fp = fp.Element{}
-	y_fp.SetBytes(y)
+	y_fp.SetBytes(xy[32:])
 
-	var p = &PointAffine{
+	return PointAffine{
 		X: x_fp,
 		Y: y_fp,
 	}
-
-	return p
 }
 // Writes an uncompressed affine point to an io.Writer
 func (p *PointAffine) WriteUncompressedPoint(w io.Writer) (int, error) {

--- a/bandersnatch/precomp_multiexp.go
+++ b/bandersnatch/precomp_multiexp.go
@@ -75,7 +75,7 @@ func DeserializePrecomputedLagrange(reader io.Reader) (*PrecomputeLagrange, erro
 		pcl.inner[i].matrix = make([]PointAffine, rowLen)
 		for j := int64(0); j < rowLen; j++ {
 
-			pcl.inner[i].matrix[j] = *ReadUncompressedPoint(reader)
+			pcl.inner[i].matrix[j] = ReadUncompressedPoint(reader)
 		}
 	}
 
@@ -83,7 +83,6 @@ func DeserializePrecomputedLagrange(reader io.Reader) (*PrecomputeLagrange, erro
 }
 
 func (p *PrecomputeLagrange) Commit(evaluations []fr.Element) *PointAffine {
-
 	nbTasks := runtime.NumCPU()
 	chPartialResults := make(chan PointProj, nbTasks)
 	parallel.Execute(len(evaluations), func(start, end int) {

--- a/bandersnatch/precomp_multiexp.go
+++ b/bandersnatch/precomp_multiexp.go
@@ -3,10 +3,8 @@ package bandersnatch
 import (
 	"encoding/binary"
 	"io"
-	"runtime"
 
 	"github.com/crate-crypto/go-ipa/bandersnatch/fr"
-	"github.com/crate-crypto/go-ipa/bandersnatch/parallel"
 )
 
 type PrecomputeLagrange struct {
@@ -83,42 +81,28 @@ func DeserializePrecomputedLagrange(reader io.Reader) (*PrecomputeLagrange, erro
 }
 
 func (p *PrecomputeLagrange) Commit(evaluations []fr.Element) *PointAffine {
-	nbTasks := runtime.NumCPU()
-	chPartialResults := make(chan PointProj, nbTasks)
-	parallel.Execute(len(evaluations), func(start, end int) {
-		var partial_result PointProj
-		partial_result.Identity()
-
-		for i := start; i < end; i++ {
-			scalar := &evaluations[i]
-
-			if scalar.IsZero() {
-				continue
-			}
-
-			table := p.inner[i]
-			scalar_bytes_le := scalar.BytesLE()
-
-			for row, byte := range scalar_bytes_le {
-				var tp = table.point(row, byte)
-				var tp_proj PointProj
-				tp_proj.FromAffine(tp)
-				partial_result.Add(&partial_result, &tp_proj)
-			}
-		}
-
-		chPartialResults <- partial_result
-
-	}, nbTasks)
-
-	// Aggregate Parallel Results
-
-	close(chPartialResults)
 	var result PointProj
 	result.Identity()
-	for partial := range chPartialResults {
-		result.Add(&result, &partial)
+
+	for i := 0; i < len(evaluations); i++ {
+		scalar := &evaluations[i]
+
+		if scalar.IsZero() {
+			continue
+		}
+
+		table := p.inner[i]
+		scalar_bytes_le := scalar.BytesLE()
+
+		for row, byte := range scalar_bytes_le {
+			var tp = table.point(row, byte)
+			var tp_proj PointProj
+			tp_proj.FromAffine(tp)
+			result.Add(&result, &tp_proj)
+		}
 	}
+
+	// Aggregate Parallel Results
 
 	var res_affine PointAffine
 	res_affine.FromProj(&result)

--- a/ipa/srs_precomp.go
+++ b/ipa/srs_precomp.go
@@ -60,7 +60,7 @@ func DeserializeSRSPrecomp(serialized []byte) (*SRSPrecompPoints, error) {
 	spc.SRS = make([]bandersnatch.PointAffine, lenSRS)
 
 	for i := 0; i < int(lenSRS); i++ {
-		spc.SRS[i] = *bandersnatch.ReadUncompressedPoint(reader)
+		spc.SRS[i] = bandersnatch.ReadUncompressedPoint(reader)
 	}
 
 	pcl, err := bandersnatch.DeserializePrecomputedLagrange(reader)


### PR DESCRIPTION
This PR contains a set of optimizations that improves the performance of the library significantly.

Using the reference benchmarks in the repo, here's a comparison in performance between `master` and this PR:
```
name                           old time/op    new time/op    delta
pkg:github.com/crate-crypto/go-ipa/bandersnatch goos:linux goarch:amd64
MultiExpG1/32_points-16           318µs ± 6%     355µs ±11%   +11.81%  (p=0.000 n=10+8)
MultiExpG1/64_points-16           354µs ± 5%     287µs ± 4%   -18.69%  (p=0.000 n=10+7)
MultiExpG1/128_points-16          450µs ± 5%     381µs ± 6%   -15.31%  (p=0.000 n=10+8)
MultiExpG1/256_points-16          649µs ± 4%     556µs ± 5%   -14.31%  (p=0.000 n=10+8)
MultiExpG1/512_points-16         1.04ms ± 4%    0.87ms ± 2%   -16.34%  (p=0.000 n=9+8)
MultiExpG1/1024_points-16        1.63ms ± 7%    1.30ms ± 3%   -20.39%  (p=0.000 n=10+8)
MultiExpG1/2048_points-16        2.85ms ± 3%    2.40ms ± 1%   -15.69%  (p=0.000 n=10+7)
MultiExpG1/4096_points-16        4.98ms ± 2%    4.17ms ± 1%   -16.37%  (p=0.000 n=10+8)
MultiExpG1/8192_points-16        9.49ms ± 0%    8.06ms ± 0%   -15.09%  (p=0.000 n=10+7)
MultiExpG1/16384_points-16       18.7ms ± 1%    15.7ms ± 1%   -15.83%  (p=0.000 n=10+8)
MultiExpG1/32768_points-16       36.0ms ± 2%    30.8ms ± 2%   -14.45%  (p=0.000 n=10+8)
MultiExpG1/65536_points-16       64.1ms ± 3%    54.3ms ± 2%   -15.25%  (p=0.000 n=10+7)
MultiExpG1/131072_points-16       109ms ± 3%      93ms ± 2%   -14.43%  (p=0.000 n=10+8)
MultiExpG1/262144_points-16       192ms ± 2%     164ms ± 7%   -14.70%  (p=0.000 n=10+8)
MultiExpG1/524288_points-16       381ms ± 2%     321ms ± 2%   -15.75%  (p=0.000 n=10+7)
MultiExpG1/1048576_points-16      722ms ± 3%     605ms ± 2%   -16.21%  (p=0.000 n=10+8)
MultiExpG1/2097152_points-16      1.41s ± 2%     1.19s ± 1%   -15.71%  (p=0.000 n=10+8)
MultiExpG1/4194304_points-16      2.82s ± 1%     2.38s ± 1%   -15.57%  (p=0.000 n=10+8)
MultiExpG1/8388608_points-16      5.69s ± 0%     5.04s ± 1%   -11.41%  (p=0.000 n=9+7)
MultiExpG1/16777216_points-16     10.6s ± 1%      9.2s ± 0%   -12.93%  (p=0.000 n=10+8)
MultiExpG1Reference-16            741ms ± 4%     608ms ± 0%   -18.04%  (p=0.000 n=9+6)
ManyMultiExpG1Reference-16        2.18s ± 2%     1.81s ± 1%   -17.23%  (p=0.000 n=10+8)

name                           old alloc/op   new alloc/op   delta
pkg:github.com/crate-crypto/go-ipa/bandersnatch goos:linux goarch:amd64
MultiExpG1/32_points-16           231kB ± 0%      18kB ± 0%   -92.38%  (p=0.000 n=9+8)
MultiExpG1/64_points-16           347kB ± 0%      21kB ± 0%   -94.06%  (p=0.000 n=8+8)
MultiExpG1/128_points-16          551kB ± 0%      23kB ± 0%   -95.89%  (p=0.000 n=9+8)
MultiExpG1/256_points-16          905kB ± 0%      24kB ± 0%   -97.37%  (p=0.000 n=10+8)
MultiExpG1/512_points-16         1.54MB ± 0%    0.03MB ± 0%   -98.06%  (p=0.000 n=10+8)
MultiExpG1/1024_points-16        2.67MB ± 0%    0.04MB ± 0%   -98.33%  (p=0.000 n=9+8)
MultiExpG1/2048_points-16        4.77MB ± 0%    0.08MB ± 0%   -98.40%  (p=0.000 n=10+8)
MultiExpG1/4096_points-16        8.59MB ± 0%    0.14MB ± 0%   -98.35%  (p=0.000 n=8+8)
MultiExpG1/8192_points-16        15.5MB ± 0%     0.3MB ± 0%   -98.25%  (p=0.000 n=10+8)
MultiExpG1/16384_points-16       28.1MB ± 0%     0.5MB ± 0%   -98.10%  (p=0.000 n=9+8)
MultiExpG1/32768_points-16       52.1MB ± 0%     1.1MB ± 0%   -97.97%  (p=0.000 n=10+8)
MultiExpG1/65536_points-16       96.0MB ± 0%     2.1MB ± 0%   -97.81%  (p=0.000 n=10+8)
MultiExpG1/131072_points-16       180MB ± 0%       4MB ± 0%   -97.67%  (p=0.000 n=10+8)
MultiExpG1/262144_points-16       329MB ± 0%       8MB ± 0%   -97.45%  (p=0.000 n=10+7)
MultiExpG1/524288_points-16       621MB ± 0%      17MB ± 0%   -97.30%  (p=0.000 n=10+8)
MultiExpG1/1048576_points-16     1.17GB ± 0%    0.03GB ± 0%   -97.14%  (p=0.000 n=10+8)
MultiExpG1/2097152_points-16     2.28GB ± 0%    0.07GB ± 0%   -97.06%  (p=0.000 n=10+8)
MultiExpG1/4194304_points-16     4.56GB ± 0%    0.13GB ± 0%   -97.06%  (p=0.000 n=8+8)
MultiExpG1/8388608_points-16     10.1GB ± 0%     1.5GB ± 0%   -85.35%  (p=0.000 n=9+8)
MultiExpG1/16777216_points-16    17.3GB ± 0%     1.7GB ± 0%   -89.93%  (p=0.000 n=10+8)
MultiExpG1Reference-16           1.17GB ± 0%    0.03GB ± 0%   -97.14%  (p=0.000 n=10+7)
ManyMultiExpG1Reference-16       3.52GB ± 0%    0.10GB ± 0%   -97.14%  (p=0.000 n=8+8)

name                           old allocs/op  new allocs/op  delta
pkg:github.com/crate-crypto/go-ipa/bandersnatch goos:linux goarch:amd64
MultiExpG1/32_points-16           3.39k ± 0%     0.09k ± 0%   -97.38%  (p=0.000 n=10+8)
MultiExpG1/64_points-16           5.22k ± 0%     0.13k ± 0%   -97.51%  (p=0.000 n=10+8)
MultiExpG1/128_points-16          8.38k ± 0%     0.13k ± 0%   -98.45%  (p=0.000 n=10+8)
MultiExpG1/256_points-16          13.9k ± 0%      0.1k ± 0%   -99.19%  (p=0.000 n=10+8)
MultiExpG1/512_points-16          23.7k ± 0%      0.1k ± 0%   -99.58%  (p=0.000 n=10+8)
MultiExpG1/1024_points-16         41.2k ± 0%      0.1k ± 0%   -99.78%  (p=0.000 n=10+8)
MultiExpG1/2048_points-16         73.4k ± 0%      0.1k ± 0%   -99.89%  (p=0.000 n=10+8)
MultiExpG1/4096_points-16          132k ± 0%        0k ± 0%   -99.94%  (p=0.000 n=10+8)
MultiExpG1/8192_points-16          238k ± 0%        0k ± 0%   -99.97%  (p=0.000 n=10+8)
MultiExpG1/16384_points-16         431k ± 0%        0k ± 0%   -99.98%  (p=0.000 n=10+8)
MultiExpG1/32768_points-16         798k ± 0%        0k ± 0%   -99.99%  (p=0.000 n=10+8)
MultiExpG1/65536_points-16        1.47M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=10+8)
MultiExpG1/131072_points-16       2.75M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=10+8)
MultiExpG1/262144_points-16       5.01M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=10+8)
MultiExpG1/524288_points-16       9.44M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=10+8)
MultiExpG1/1048576_points-16      17.8M ± 0%      0.0M ± 0%  -100.00%  (p=0.000 n=10+8)
MultiExpG1/2097152_points-16      34.6M ± 0%      0.0M ± 1%  -100.00%  (p=0.000 n=10+8)
MultiExpG1/4194304_points-16      69.2M ± 0%      0.0M ± 1%  -100.00%  (p=0.000 n=10+8)
MultiExpG1/8388608_points-16       134M ± 0%        0M ± 1%  -100.00%  (p=0.000 n=10+8)
MultiExpG1/16777216_points-16      243M ± 0%        0M ± 3%  -100.00%  (p=0.000 n=10+7)
MultiExpG1Reference-16            17.8M ± 0%      0.0M ± 0%  -100.00%  (p=0.000 n=10+8)
ManyMultiExpG1Reference-16        53.5M ± 0%      0.0M ± 2%  -100.00%  (p=0.000 n=9+8)
```
A TL;DR:
- Around 15% reduction in computation time in most sub-tests, with 32-points being a bit of an outlier.
- The performance gain comes from avoiding allocations, which clearly is shown by reducing by more than 95% and some functions completely stopping doing memory allocations.

The original focus to guide the optimizations was making `go-verkle` faster for generating and verifying proofs.

To understand the impact of these optimizations in `go-verkle` see [this PR](https://github.com/gballet/go-verkle/pull/213).

I'm not entirely sure if the repo is open for PRs from external contributors; if this PR is looking good to consider for merging I can add some comments on the changes.  

Let me know!