### PR TITLE
bandersnatch/fp: more performant Inv implementation

### DIFF
--- a/bandersnatch/fp/arith.go
+++ b/bandersnatch/fp/arith.go
@@ -58,3 +58,10 @@ func madd3(a, b, c, d, e uint64) (hi uint64, lo uint64) {
 	hi, _ = bits.Add64(hi, e, carry)
 	return
 }
+
+func min(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
This PR updates our `(*Element).Inverse(...)` implementation with a newer version of `goff` generated code. `goff` is a CLI tool from [gnark-crypto](https://github.com/ConsenSys/gnark-crypto/tree/master/field/goff) that is used to generate Go ECC implementations of different curves (e.g: [their BLS12-381 implementation](https://github.com/ConsenSys/gnark-crypto/tree/master/ecc/bls12-381)).

So I ran `go run ./field/goff -m 52435875175126190479447740508185965837690552500527637822603658699938581184513 -o go-ipa-bls -p fr -e Element`, and got the new version of the implementation.

I focused only in manually porting the `(*Element).Inverse(...)` new version for multiple reasons:

- I wanted to change as few lines as possible in `go-ipa`.
- I wanted to keep all the existing tests, since changing tests while changing implementation is tricky to ensure the new implementation behaves the same as the previous one.
- In a separate branch, I benchmarked if we could get more benefits in other functions than `Inverse(...)` and saw similar or even regressions in performance. This isn’t surprising since our `go-ipa` implementation had some optimizations before, mostly regarding avoiding memory allocations.

Here’s a benchmark comparison of the existing `ElementInverse` benchmark in this repo before and after the change:

```markdown
name               old time/op    new time/op    delta
ElementInverse-16    1.69µs ± 4%    1.13µs ± 1%  -32.99%  (p=0.000 n=15+12)
```

Optimizing the `Inverse(..)` function directly impacts important use cases for Verkle Tries regarding doing the Pedersen Hashes to map keys in the Trie. 

See here to see how this impacted other existing benchmarks.