### PR TITLE
Avoid forced heap escaping for polynomial commitment

### DIFF
--- a/banderwagon/precomp_multiexp.go
+++ b/banderwagon/precomp_multiexp.go
@@ -15,7 +15,6 @@ type PrecomputeLagrange struct {
 }
 
 func (pcl PrecomputeLagrange) Equal(other PrecomputeLagrange) bool {
-
 	if pcl.num_points != other.num_points {
 		return false
 	}
@@ -34,15 +33,12 @@ func (pcl PrecomputeLagrange) Equal(other PrecomputeLagrange) bool {
 }
 
 func NewPrecomputeLagrange(points []Element) *PrecomputeLagrange {
-
 	table := make([]*LagrangeTablePoints, len(points))
 	parallel.Execute(len(points), func(start, end int) {
-
 		for i := start; i < end; i++ {
 			point := points[i]
 			table[i] = newLagrangeTablePoints(point)
 		}
-
 	})
 
 	return &PrecomputeLagrange{
@@ -52,7 +48,6 @@ func NewPrecomputeLagrange(points []Element) *PrecomputeLagrange {
 }
 
 func (pcl *PrecomputeLagrange) SerializePrecomputedLagrange(w io.Writer) error {
-
 	err := binary.Write(w, binary.LittleEndian, int64(pcl.num_points))
 	if err != nil {
 		return err
@@ -98,7 +93,6 @@ func DeserializePrecomputedLagrange(reader io.Reader) (*PrecomputeLagrange, erro
 		// Deserialize the matrix
 		pcl.inner[i].matrix = make([]bandersnatch.PointAffine, rowLen)
 		for j := int64(0); j < rowLen; j++ {
-
 			pcl.inner[i].matrix[j] = bandersnatch.ReadUncompressedPoint(reader)
 		}
 	}
@@ -106,7 +100,7 @@ func DeserializePrecomputedLagrange(reader io.Reader) (*PrecomputeLagrange, erro
 	return &pcl, nil
 }
 
-func (p *PrecomputeLagrange) Commit(evaluations []fr.Element) *Element {
+func (p *PrecomputeLagrange) Commit(evaluations []fr.Element) Element {
 	var result Element
 	result.Identity()
 
@@ -124,11 +118,11 @@ func (p *PrecomputeLagrange) Commit(evaluations []fr.Element) *Element {
 			if byte == 0 {
 				continue
 			}
-			var tp = table.point(row, byte)
+			tp := table.point(row, byte)
 			result.AddMixed(&result, *tp)
 		}
 	}
-	return &result
+	return result
 }
 
 type LagrangeTablePoints struct {
@@ -166,7 +160,7 @@ func newLagrangeTablePoints(point Element) *LagrangeTablePoints {
 	var rows []Element
 	rows = append(rows, base_row...)
 
-	var scale = base
+	scale := base
 	// TODO: we can do this in parallel
 	for i := 1; i < num_rows; i++ {
 
@@ -191,7 +185,6 @@ func (ltp *LagrangeTablePoints) point(index int, value uint8) *bandersnatch.Poin
 }
 
 func compute_base_row(point Element, num_points int) []Element {
-
 	row := make([]Element, num_points)
 	row[0] = point
 

--- a/ipa/config.go
+++ b/ipa/config.go
@@ -47,7 +47,7 @@ func multiScalar(points []banderwagon.Element, scalars []fr.Element) banderwagon
 	var result banderwagon.Element
 	result.Identity()
 
-	var res, err = result.MultiExp(points, scalars, banderwagon.MultiExpConfig{NbTasks: runtime.NumCPU(), ScalarsMont: true})
+	res, err := result.MultiExp(points, scalars, banderwagon.MultiExpConfig{NbTasks: runtime.NumCPU(), ScalarsMont: true})
 	if err != nil {
 		panic("mult exponentiation was not successful. TODO: replace panics by bubbling up error")
 	}
@@ -58,7 +58,7 @@ func multiScalar(points []banderwagon.Element, scalars []fr.Element) banderwagon
 // Commits to a polynomial using the SRS
 // panics if the length of the SRS does not equal the number of polynomial coefficients
 func (ic *IPAConfig) Commit(polynomial []fr.Element) banderwagon.Element {
-	return *ic.SRSPrecompPoints.PrecompLag.Commit(polynomial)
+	return ic.SRSPrecompPoints.PrecompLag.Commit(polynomial)
 }
 
 // Commits to a polynomial using the input group elements
@@ -93,7 +93,6 @@ func InnerProd(a []fr.Element, b []fr.Element) fr.Element {
 // returns c
 // panics if len(a) != len(b)
 func foldScalars(a []fr.Element, b []fr.Element, x fr.Element) []fr.Element {
-
 	if len(a) != len(b) {
 		panic("slices not equal length")
 	}
@@ -111,7 +110,6 @@ func foldScalars(a []fr.Element, b []fr.Element, x fr.Element) []fr.Element {
 // returns c
 // panics if len(a) != len(b)
 func foldPoints(a []banderwagon.Element, b []banderwagon.Element, x fr.Element) []banderwagon.Element {
-
 	if len(a) != len(b) {
 		panic("slices not equal length")
 	}
@@ -176,7 +174,6 @@ func compute_num_rounds(vector_size uint32) uint32 {
 }
 
 func GenerateRandomPoints(numPoints uint64) []banderwagon.Element {
-
 	seed := "eth_verkle_oct_2021" // incase it changes or needs updating, we can use eth_verkle_month_year
 
 	points := []banderwagon.Element{}


### PR DESCRIPTION
This PR avoids a forced heap allocation since it avoids returning a pointer from a stack variable. This was noticed while looking at profiling information in `go-verkle`.

It also removes an unnecessary assignment.

Linked to https://github.com/gballet/go-verkle/pull/314