### PR TITLE
point: allow compressed and uncompressed serialization

### DIFF
--- a/bandersnatch/point.go
+++ b/bandersnatch/point.go
@@ -459,7 +459,6 @@ func (p PointAffine) IsInPrimeSubgroup() bool {
 }
 
 func GetPointFromX(x *fp.Element, choose_largest bool) *PointAffine {
-
 	y := computeY(x, choose_largest)
 	if y == nil { // not a square
 		return nil

--- a/banderwagon/element_test.go
+++ b/banderwagon/element_test.go
@@ -33,7 +33,7 @@ func TestEncodingFixedVectors(t *testing.T) {
 	point := Generator
 	// Check encoding is as expected
 	for i := 0; i < 16; i++ {
-		byts := point.Bytes()
+		byts := point.BytesCompressed()
 		if expected_bit_strings[i] != hex.EncodeToString(byts[:]) {
 			panic("bit string does not match expected")
 		}
@@ -50,7 +50,7 @@ func TestEncodingFixedVectors(t *testing.T) {
 		}
 
 		var element Element
-		err = element.SetBytes(bytes)
+		err = element.SetBytesCompressed(bytes)
 		if err != nil {
 			panic("point was decoded as invalid")
 		}
@@ -81,8 +81,8 @@ func TestTwoTorsionEqual(t *testing.T) {
 			panic("points that differ by an order-2 point should be equal")
 		}
 
-		expected_bit_string := point.Bytes()
-		got_bit_string := point_plus_torsion.Bytes()
+		expected_bit_string := point.BytesCompressed()
+		got_bit_string := point_plus_torsion.BytesCompressed()
 		if expected_bit_string != got_bit_string {
 			panic("points that differ by an order-2 point should produce the same bit string")
 		}

--- a/common/common.go
+++ b/common/common.go
@@ -29,16 +29,16 @@ func PowersOf(x fr.Element, degree int) []fr.Element {
 }
 
 func ReadPoint(r io.Reader) *banderwagon.Element {
-	var x = make([]byte, 32)
+	x := make([]byte, banderwagon.SerializedAffinePointCompressedSize)
 	n, err := r.Read(x)
 	if err != nil {
 		panic("error reading bytes")
 	}
-	if n != 32 {
+	if n != banderwagon.SerializedAffinePointCompressedSize {
 		panic("did not read enough bytes")
 	}
-	var p = &banderwagon.Element{}
-	err = p.SetBytes(x)
+	p := &banderwagon.Element{}
+	err = p.SetBytesCompressed(x)
 	if err != nil {
 		panic("could not deserialize point")
 	}
@@ -46,7 +46,7 @@ func ReadPoint(r io.Reader) *banderwagon.Element {
 }
 
 func ReadScalar(r io.Reader) *fr.Element {
-	var x = make([]byte, 32)
+	x := make([]byte, 32)
 	n, err := r.Read(x)
 	if err != nil {
 		panic("error reading bytes")
@@ -54,7 +54,7 @@ func ReadScalar(r io.Reader) *fr.Element {
 	if n != 32 {
 		panic("did not read enough bytes")
 	}
-	var scalar = &fr.Element{}
+	scalar := &fr.Element{}
 	scalar.SetBytesLE(x)
 	if err != nil {
 		panic("could not deserialize point")

--- a/common/transcript.go
+++ b/common/transcript.go
@@ -8,8 +8,8 @@ import (
 	"github.com/crate-crypto/go-ipa/banderwagon"
 )
 
-/// The transcript is used to create challenge scalars.
-/// See: Fiat-Shamir
+// / The transcript is used to create challenge scalars.
+// / See: Fiat-Shamir
 type Transcript struct {
 	state hash.Hash
 }
@@ -37,7 +37,6 @@ func (t *Transcript) AppendMessage(message []byte, label string) {
 func (t *Transcript) AppendScalar(scalar *fr.Element, label string) {
 	tmpBytes := scalar.BytesLE()
 	t.AppendMessage(tmpBytes[:], label)
-
 }
 
 // Appends a Point to the transcript
@@ -45,9 +44,8 @@ func (t *Transcript) AppendScalar(scalar *fr.Element, label string) {
 // Compresses the Point into a 32 byte slice, then appends it to
 // the state
 func (t *Transcript) AppendPoint(point *banderwagon.Element, label string) {
-	tmp_bytes := point.Bytes()
+	tmp_bytes := point.BytesCompressed()
 	t.AppendMessage(tmp_bytes[:], label)
-
 }
 
 func (t *Transcript) DomainSep(label string) {

--- a/ipa/config.go
+++ b/ipa/config.go
@@ -198,7 +198,7 @@ func GenerateRandomPoints(numPoints uint64) []banderwagon.Element {
 
 		x_as_bytes := x.Bytes()
 		var point_found banderwagon.Element
-		err := point_found.SetBytes(x_as_bytes[:])
+		err := point_found.SetBytesCompressed(x_as_bytes[:])
 		if err != nil {
 			// This point is not in the correct subgroup or on the curve
 			continue

--- a/ipa/ipa_test.go
+++ b/ipa/ipa_test.go
@@ -15,7 +15,6 @@ import (
 var ipaConf = NewIPASettings()
 
 func TestIPAProofCreateVerify(t *testing.T) {
-
 	// Shared View
 	var point fr.Element
 	point.SetUint64(123456789)
@@ -40,10 +39,9 @@ func TestIPAProofCreateVerify(t *testing.T) {
 	if !ok {
 		panic("inner product proof failed")
 	}
-
 }
-func TestIPAConsistencySimpleProof(t *testing.T) {
 
+func TestIPAConsistencySimpleProof(t *testing.T) {
 	// Shared View
 	var input_point fr.Element
 	input_point.SetUint64(2101)
@@ -96,7 +94,7 @@ func TestIPAConsistencySimpleProof(t *testing.T) {
 	// Check that the serialised proof matches the other implementations
 	expected := "273395a8febdaed38e94c3d874e99c911a47dd84616d54c55021d5c4131b507e46a4ec2c7e82b77ec2f533994c91ca7edaef212c666a1169b29c323eabb0cf690e0146638d0e2d543f81da4bd597bf3013e1663f340a8f87b845495598d0a3951590b6417f868edaeb3424ff174901d1185a53a3ee127fb7be0af42dda44bf992885bde279ef821a298087717ef3f2b78b2ede7f5d2ea1b60a4195de86a530eb247fd7e456012ae9a070c61635e55d1b7a340dfab8dae991d6273d099d9552815434cc1ba7bcdae341cf7928c6f25102370bdf4b26aad3af654d9dff4b3735661db3177342de5aad774a59d3e1b12754aee641d5f9cd1ecd2751471b308d2d8410add1c9fcc5a2b7371259f0538270832a98d18151f653efbc60895fab8be9650510449081626b5cd24671d1a3253487d44f589c2ff0da3557e307e520cf4e0054bbf8bdffaa24b7e4cce5092ccae5a08281ee24758374f4e65f126cacce64051905b5e2038060ad399c69ca6cb1d596d7c9cb5e161c7dcddc1a7ad62660dd4a5f69b31229b80e6b3df520714e4ea2b5896ebd48d14c7455e91c1ecf4acc5ffb36937c49413b7d1005dd6efbd526f5af5d61131ca3fcdae1218ce81c75e62b39100ec7f474b48a2bee6cef453fa1bc3db95c7c6575bc2d5927cbf7413181ac905766a4038a7b422a8ef2bf7b5059b5c546c19a33c1049482b9a9093f864913ca82290decf6e9a65bf3f66bc3ba4a8ed17b56d890a83bcbe74435a42499dec115"
 
-	var buf = new(bytes.Buffer)
+	buf := new(bytes.Buffer)
 	proof.Write(buf)
 
 	bytes := buf.Bytes()
@@ -104,8 +102,8 @@ func TestIPAConsistencySimpleProof(t *testing.T) {
 		panic("expected serialised proof is different from the other implementations")
 	}
 }
-func TestBasicInnerProduct(t *testing.T) {
 
+func TestBasicInnerProduct(t *testing.T) {
 	var a []fr.Element
 	for i := 0; i < 10; i++ {
 		var tmp fr.Element
@@ -131,8 +129,8 @@ func TestBasicInnerProduct(t *testing.T) {
 		panic("the inner product should just be the sum of a since b is just 1")
 	}
 }
-func TestBasicCommit(t *testing.T) {
 
+func TestBasicCommit(t *testing.T) {
 	gen := banderwagon.Generator
 
 	var generators []banderwagon.Element
@@ -174,8 +172,8 @@ func TestCRSGeneration(t *testing.T) {
 		// Check point is in the correct subgroup by doing
 		// serialise deserialise roundtrip
 
-		bytes := point.Bytes()
-		err := point.SetBytes(bytes[:])
+		bytes := point.BytesCompressed()
+		err := point.SetBytesCompressed(bytes[:])
 		if err != nil {
 			panic("point is not in the banderwagon subgroup")
 		}
@@ -192,14 +190,13 @@ func TestCRSGeneration(t *testing.T) {
 
 	// Now check against the test vectors here: https://hackmd.io/1RcGSMQgT4uREaq1CCx_cg#Methodology
 	// TODO: This hackmd document needs to be updated
-	bytes := points[0].Bytes()
+	bytes := points[0].BytesCompressed()
 	got := hex.EncodeToString(bytes[:])
 	expected := "01587ad1336675eb912550ec2a28eb8923b824b490dd2ba82e48f14590a298a0"
 	if got != expected {
-		panic("the first point is not correct")
-
+		t.Fatalf("the first point is not correct, got: %v, exp: %v", got, expected)
 	}
-	bytes = points[255].Bytes()
+	bytes = points[255].BytesCompressed()
 	got = hex.EncodeToString(bytes[:])
 	expected = "3de2be346b539395b0c0de56a5ccca54a317f1b5c80107b0802af9a62276a4d8"
 	if got != expected {
@@ -208,7 +205,7 @@ func TestCRSGeneration(t *testing.T) {
 
 	digest := sha256.New()
 	for _, point := range points {
-		bytes := point.Bytes()
+		bytes := point.BytesCompressed()
 		digest.Write(bytes[:])
 	}
 	hash := digest.Sum(nil)
@@ -217,11 +214,10 @@ func TestCRSGeneration(t *testing.T) {
 	if got != expected {
 		panic("unexpected point encountered")
 	}
-
 }
 
 func test_serialize_deserialize_proof(proof IPAProof) {
-	var buf = new(bytes.Buffer)
+	buf := new(bytes.Buffer)
 	proof.Write(buf)
 
 	var got_proof IPAProof

--- a/ipa/prover.go
+++ b/ipa/prover.go
@@ -84,10 +84,10 @@ func CreateIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment ban
 
 func (ip *IPAProof) Write(w io.Writer) {
 	for _, el := range ip.L {
-		binary.Write(w, binary.BigEndian, el.Bytes())
+		binary.Write(w, binary.BigEndian, el.BytesCompressed())
 	}
 	for _, ar := range ip.R {
-		binary.Write(w, binary.BigEndian, ar.Bytes())
+		binary.Write(w, binary.BigEndian, ar.BytesCompressed())
 	}
 	binary.Write(w, binary.BigEndian, ip.A_scalar.BytesLE())
 }

--- a/ipa/verifier.go
+++ b/ipa/verifier.go
@@ -89,7 +89,6 @@ func CheckIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment band
 }
 
 func generateChallenges(transcript *common.Transcript, proof *IPAProof) []fr.Element {
-
 	challenges := make([]fr.Element, len(proof.L))
 	for i := 0; i < len(proof.L); i++ {
 		transcript.AppendPoint(&proof.L[i], "L")

--- a/multiproof.go
+++ b/multiproof.go
@@ -34,7 +34,7 @@ func CreateMultiProof(transcript *common.Transcript, ipaConf *ipa.IPAConfig, Cs 
 
 	for i := 0; i < num_queries; i++ {
 		transcript.AppendPoint(Cs[i], "C")
-		var z = domainToFr(zs[i])
+		z := domainToFr(zs[i])
 		transcript.AppendScalar(&z, "z")
 
 		// get the `y` value
@@ -77,7 +77,7 @@ func CreateMultiProof(transcript *common.Transcript, ipaConf *ipa.IPAConfig, Cs 
 		f := fs[i]
 
 		var den_inv fr.Element
-		var z = domainToFr(zs[i])
+		z := domainToFr(zs[i])
 		den_inv.Sub(&t, &z)
 		den_inv.Inverse(&den_inv)
 
@@ -130,7 +130,7 @@ func CheckMultiProof(transcript *common.Transcript, ipaConf *ipa.IPAConfig, proo
 
 	for i := 0; i < num_queries; i++ {
 		transcript.AppendPoint(Cs[i], "C")
-		var z = domainToFr(zs[i])
+		z := domainToFr(zs[i])
 		transcript.AppendScalar(&z, "z")
 		transcript.AppendScalar(ys[i], "y")
 	}
@@ -149,7 +149,7 @@ func CheckMultiProof(transcript *common.Transcript, ipaConf *ipa.IPAConfig, proo
 		r := powers_of_r[i]
 
 		// r^i / (t - z_i)
-		var z = domainToFr(zs[i])
+		z := domainToFr(zs[i])
 		helper_scalars[i].Sub(&t, &z)
 		helper_scalars[i].Inverse(&helper_scalars[i])
 		helper_scalars[i].Mul(&helper_scalars[i], &r)
@@ -186,7 +186,7 @@ func domainToFr(in uint8) fr.Element {
 }
 
 func (mp *MultiProof) Write(w io.Writer) {
-	binary.Write(w, binary.BigEndian, mp.D.Bytes())
+	binary.Write(w, binary.BigEndian, mp.D.BytesCompressed())
 	mp.IPA.Write(w)
 }
 
@@ -195,6 +195,7 @@ func (mp *MultiProof) Read(r io.Reader) {
 	mp.D = *D
 	mp.IPA.Read(r)
 }
+
 func (mp MultiProof) Equal(other MultiProof) bool {
 	if !mp.IPA.Equal(other.IPA) {
 		return false

--- a/test_helper/poly.go
+++ b/test_helper/poly.go
@@ -27,12 +27,13 @@ func TestPoly256(polynomial ...uint64) []fr.Element {
 }
 
 func PointEqualHex(t *testing.T, point banderwagon.Element, expected string) {
-	point_bytes := point.Bytes()
+	point_bytes := point.BytesCompressed()
 	got := hex.EncodeToString(point_bytes[:])
 	if got != expected {
 		t.Fatalf("point does not equal expected hex value, expected %s got %s", expected, got)
 	}
 }
+
 func ScalarEqualHex(t *testing.T, scalar fr.Element, expected string) {
 	scalar_bytes := scalar.BytesLE()
 	got := hex.EncodeToString(scalar_bytes[:])


### PR DESCRIPTION
This PR is an experimental change to change our elliptic curve point serialization from compressed to uncompressed by default. 

We still keep the compressed flavor used in proofs, since the main intention is to see how this improves the performance in `go-verkle` regarding deserializing points.

The main intention of this PR is to support an experimental [go-verkle version](https://github.com/gballet/go-verkle/pull/323).