### PR TITLE
point: allow compressed and uncompressed serialization

### DIFF
--- a/banderwagon/element.go
+++ b/banderwagon/element.go
@@ -16,8 +16,8 @@ const (
 )
 
 type (
-	SerializedAffinePoint           []byte
-	SerializedAffinePointCompressed []byte
+	SerializedPoint           []byte
+	SerializedPointCompressed []byte
 )
 
 var Generator = Element{inner: bandersnatch.PointProj{
@@ -38,7 +38,7 @@ type Element struct {
 	inner bandersnatch.PointProj
 }
 
-func (p Element) Bytes() SerializedAffinePointCompressed {
+func (p Element) Bytes() SerializedPointCompressed {
 	// Convert underlying point to affine representation
 	var affine_representation bandersnatch.PointAffine
 	affine_representation.FromProj(&p.inner)
@@ -53,7 +53,7 @@ func (p Element) Bytes() SerializedAffinePointCompressed {
 	return compressedPoint[:]
 }
 
-func (p *Element) SetBytes(buf SerializedAffinePointCompressed, trusted bool) error {
+func (p *Element) SetBytes(buf SerializedPointCompressed, trusted bool) error {
 	// set the buffer which is x * SignY as X
 	var x fp.Element
 	x.SetBytes(buf[:])
@@ -79,7 +79,7 @@ func (p *Element) SetBytes(buf SerializedAffinePointCompressed, trusted bool) er
 	return nil
 }
 
-func (p Element) BytesUncompressed() SerializedAffinePoint {
+func (p Element) BytesUncompressed() SerializedPoint {
 	// Convert underlying point to affine representation
 	var affine_representation bandersnatch.PointAffine
 	affine_representation.FromProj(&p.inner)
@@ -87,7 +87,7 @@ func (p Element) BytesUncompressed() SerializedAffinePoint {
 	xbytes := affine_representation.X.Bytes()
 	ybytes := affine_representation.Y.Bytes()
 
-	xy := make(SerializedAffinePoint, SerializedPointSize)
+	xy := make(SerializedPoint, SerializedPointSize)
 	copy(xy, xbytes[:])
 	copy(xy[coordinateSize:], ybytes[:])
 
@@ -96,7 +96,7 @@ func (p Element) BytesUncompressed() SerializedAffinePoint {
 
 // Deserialises bytes into a group element
 // assuming the input is not trusted
-func (p *Element) SetBytesUncompressed(buf SerializedAffinePoint, trusted bool) error {
+func (p *Element) SetBytesUncompressed(buf SerializedPoint, trusted bool) error {
 	var x fp.Element
 	x.SetBytes(buf[:coordinateSize])
 
@@ -121,7 +121,7 @@ func (p *Element) SetBytesUncompressed(buf SerializedAffinePoint, trusted bool) 
 }
 
 // Serialises multiple group elements using a batch multi inversion
-func ElementsToBytesUncompressed(elements []*Element) []SerializedAffinePoint {
+func ElementsToBytesUncompressed(elements []*Element) []SerializedPoint {
 	// Collect all z co-ordinates
 	zs := make([]fp.Element, len(elements))
 	for i := 0; i < int(len(elements)); i++ {
@@ -132,7 +132,7 @@ func ElementsToBytesUncompressed(elements []*Element) []SerializedAffinePoint {
 	zInvs := fp.BatchInvert(zs)
 
 	// compressedPoints := make([]SerializedAffinePointCompressed, len(elements))
-	uncompressedPoints := make([]SerializedAffinePoint, len(elements))
+	uncompressedPoints := make([]SerializedPoint, len(elements))
 
 	// Multiply x and y by zInv
 	for i := 0; i < int(len(elements)); i++ {
@@ -147,7 +147,7 @@ func ElementsToBytesUncompressed(elements []*Element) []SerializedAffinePoint {
 		// compressedPoints[i] = element.Bytes()
 		xbytes := X.Bytes()
 		ybytes := Y.Bytes()
-		uncompressedPoints[i] = make(SerializedAffinePoint, SerializedPointSize)
+		uncompressedPoints[i] = make(SerializedPoint, SerializedPointSize)
 		copy(uncompressedPoints[i][:], xbytes[:])
 		copy(uncompressedPoints[i][coordinateSize:], ybytes[:])
 	}
@@ -324,7 +324,7 @@ func (element *Element) UnsafeWriteUncompressedPoint(w io.Writer) (int, error) {
 	return p.WriteUncompressedPoint(w)
 }
 
-func (sp SerializedAffinePoint) ToCompressed() SerializedAffinePointCompressed {
+func (sp SerializedPoint) ToCompressed() SerializedPointCompressed {
 	// Deserialize `y` since we have to do the lexicographical check.
 	var y fp.Element
 	y.SetBytes(sp[SerializedPointCompressedSize:])
@@ -340,5 +340,5 @@ func (sp SerializedAffinePoint) ToCompressed() SerializedAffinePointCompressed {
 	}
 
 	// We're lucky in this case, return the original `x` bytes.
-	return SerializedAffinePointCompressed(sp[:SerializedPointCompressedSize])
+	return SerializedPointCompressed(sp[:SerializedPointCompressedSize])
 }

--- a/banderwagon/element_test.go
+++ b/banderwagon/element_test.go
@@ -50,7 +50,7 @@ func TestEncodingFixedVectors(t *testing.T) {
 		}
 
 		var element Element
-		err = element.SetBytes(bytes)
+		err = element.SetBytes(bytes, false)
 		if err != nil {
 			panic("point was decoded as invalid")
 		}
@@ -83,7 +83,7 @@ func TestTwoTorsionEqual(t *testing.T) {
 
 		expected_bit_string := point.Bytes()
 		got_bit_string := point_plus_torsion.Bytes()
-		if expected_bit_string != got_bit_string {
+		if !bytes.Equal(expected_bit_string, got_bit_string) {
 			panic("points that differ by an order-2 point should produce the same bit string")
 		}
 
@@ -120,7 +120,7 @@ func TestPointAtInfinityComponent(t *testing.T) {
 			panic("malformed byte string")
 		}
 
-		err = element.SetBytes(byts)
+		err = element.SetBytesUncompressed(byts, false)
 		if err == nil {
 			panic("point should not be in the correct subgroup as it has an infinity component")
 		}
@@ -170,17 +170,17 @@ func TestBatchElementsToBytes(t *testing.T) {
 	A.Add(&Generator, &Generator)
 	B.Double(&Generator)
 
-	expected_serialised_a := A.Bytes()
-	expected_serialised_b := B.Bytes()
+	expected_serialised_a := A.BytesUncompressed()
+	expected_serialised_b := B.BytesUncompressed()
 
-	serialised_points := ElementsToBytes([]*Element{&A, &B})
+	serialised_points := ElementsToBytesUncompressed([]*Element{&A, &B})
 
 	got_serialised_a := serialised_points[0]
 	got_serialised_b := serialised_points[1]
-	if expected_serialised_a != got_serialised_a {
+	if !bytes.Equal(expected_serialised_a, got_serialised_a) {
 		panic("expected serialised point of A is incorrect ")
 	}
-	if expected_serialised_b != got_serialised_b {
+	if !bytes.Equal(expected_serialised_b, got_serialised_b) {
 		panic("expected serialised point of B is incorrect ")
 	}
 }

--- a/common/common.go
+++ b/common/common.go
@@ -29,7 +29,7 @@ func PowersOf(x fr.Element, degree int) []fr.Element {
 }
 
 func ReadPoint(r io.Reader) *banderwagon.Element {
-	var x = make([]byte, 32)
+	x := make([]byte, 32)
 	n, err := r.Read(x)
 	if err != nil {
 		panic("error reading bytes")
@@ -37,8 +37,8 @@ func ReadPoint(r io.Reader) *banderwagon.Element {
 	if n != 32 {
 		panic("did not read enough bytes")
 	}
-	var p = &banderwagon.Element{}
-	err = p.SetBytes(x)
+	p := &banderwagon.Element{}
+	err = p.SetBytes(banderwagon.SerializedAffinePointCompressed(x), false)
 	if err != nil {
 		panic("could not deserialize point")
 	}
@@ -46,7 +46,7 @@ func ReadPoint(r io.Reader) *banderwagon.Element {
 }
 
 func ReadScalar(r io.Reader) *fr.Element {
-	var x = make([]byte, 32)
+	x := make([]byte, 32)
 	n, err := r.Read(x)
 	if err != nil {
 		panic("error reading bytes")
@@ -54,7 +54,7 @@ func ReadScalar(r io.Reader) *fr.Element {
 	if n != 32 {
 		panic("did not read enough bytes")
 	}
-	var scalar = &fr.Element{}
+	scalar := &fr.Element{}
 	scalar.SetBytesLE(x)
 	if err != nil {
 		panic("could not deserialize point")

--- a/common/common.go
+++ b/common/common.go
@@ -38,7 +38,7 @@ func ReadPoint(r io.Reader) *banderwagon.Element {
 		panic("did not read enough bytes")
 	}
 	p := &banderwagon.Element{}
-	err = p.SetBytes(banderwagon.SerializedAffinePointCompressed(x), false)
+	err = p.SetBytes(banderwagon.SerializedPointCompressed(x), false)
 	if err != nil {
 		panic("could not deserialize point")
 	}

--- a/ipa/config.go
+++ b/ipa/config.go
@@ -198,7 +198,7 @@ func GenerateRandomPoints(numPoints uint64) []banderwagon.Element {
 
 		x_as_bytes := x.Bytes()
 		var point_found banderwagon.Element
-		err := point_found.SetBytes(x_as_bytes[:])
+		err := point_found.SetBytes(x_as_bytes[:], false)
 		if err != nil {
 			// This point is not in the correct subgroup or on the curve
 			continue

--- a/ipa/ipa_test.go
+++ b/ipa/ipa_test.go
@@ -15,7 +15,6 @@ import (
 var ipaConf = NewIPASettings()
 
 func TestIPAProofCreateVerify(t *testing.T) {
-
 	// Shared View
 	var point fr.Element
 	point.SetUint64(123456789)
@@ -40,10 +39,9 @@ func TestIPAProofCreateVerify(t *testing.T) {
 	if !ok {
 		panic("inner product proof failed")
 	}
-
 }
-func TestIPAConsistencySimpleProof(t *testing.T) {
 
+func TestIPAConsistencySimpleProof(t *testing.T) {
 	// Shared View
 	var input_point fr.Element
 	input_point.SetUint64(2101)
@@ -96,7 +94,7 @@ func TestIPAConsistencySimpleProof(t *testing.T) {
 	// Check that the serialised proof matches the other implementations
 	expected := "273395a8febdaed38e94c3d874e99c911a47dd84616d54c55021d5c4131b507e46a4ec2c7e82b77ec2f533994c91ca7edaef212c666a1169b29c323eabb0cf690e0146638d0e2d543f81da4bd597bf3013e1663f340a8f87b845495598d0a3951590b6417f868edaeb3424ff174901d1185a53a3ee127fb7be0af42dda44bf992885bde279ef821a298087717ef3f2b78b2ede7f5d2ea1b60a4195de86a530eb247fd7e456012ae9a070c61635e55d1b7a340dfab8dae991d6273d099d9552815434cc1ba7bcdae341cf7928c6f25102370bdf4b26aad3af654d9dff4b3735661db3177342de5aad774a59d3e1b12754aee641d5f9cd1ecd2751471b308d2d8410add1c9fcc5a2b7371259f0538270832a98d18151f653efbc60895fab8be9650510449081626b5cd24671d1a3253487d44f589c2ff0da3557e307e520cf4e0054bbf8bdffaa24b7e4cce5092ccae5a08281ee24758374f4e65f126cacce64051905b5e2038060ad399c69ca6cb1d596d7c9cb5e161c7dcddc1a7ad62660dd4a5f69b31229b80e6b3df520714e4ea2b5896ebd48d14c7455e91c1ecf4acc5ffb36937c49413b7d1005dd6efbd526f5af5d61131ca3fcdae1218ce81c75e62b39100ec7f474b48a2bee6cef453fa1bc3db95c7c6575bc2d5927cbf7413181ac905766a4038a7b422a8ef2bf7b5059b5c546c19a33c1049482b9a9093f864913ca82290decf6e9a65bf3f66bc3ba4a8ed17b56d890a83bcbe74435a42499dec115"
 
-	var buf = new(bytes.Buffer)
+	buf := new(bytes.Buffer)
 	proof.Write(buf)
 
 	bytes := buf.Bytes()
@@ -104,8 +102,8 @@ func TestIPAConsistencySimpleProof(t *testing.T) {
 		panic("expected serialised proof is different from the other implementations")
 	}
 }
-func TestBasicInnerProduct(t *testing.T) {
 
+func TestBasicInnerProduct(t *testing.T) {
 	var a []fr.Element
 	for i := 0; i < 10; i++ {
 		var tmp fr.Element
@@ -131,8 +129,8 @@ func TestBasicInnerProduct(t *testing.T) {
 		panic("the inner product should just be the sum of a since b is just 1")
 	}
 }
-func TestBasicCommit(t *testing.T) {
 
+func TestBasicCommit(t *testing.T) {
 	gen := banderwagon.Generator
 
 	var generators []banderwagon.Element
@@ -175,7 +173,7 @@ func TestCRSGeneration(t *testing.T) {
 		// serialise deserialise roundtrip
 
 		bytes := point.Bytes()
-		err := point.SetBytes(bytes[:])
+		err := point.SetBytes(bytes, false)
 		if err != nil {
 			panic("point is not in the banderwagon subgroup")
 		}
@@ -196,8 +194,7 @@ func TestCRSGeneration(t *testing.T) {
 	got := hex.EncodeToString(bytes[:])
 	expected := "01587ad1336675eb912550ec2a28eb8923b824b490dd2ba82e48f14590a298a0"
 	if got != expected {
-		panic("the first point is not correct")
-
+		t.Fatalf("the first point is not correct, got: %v, exp: %v", got, expected)
 	}
 	bytes = points[255].Bytes()
 	got = hex.EncodeToString(bytes[:])
@@ -217,11 +214,10 @@ func TestCRSGeneration(t *testing.T) {
 	if got != expected {
 		panic("unexpected point encountered")
 	}
-
 }
 
 func test_serialize_deserialize_proof(proof IPAProof) {
-	var buf = new(bytes.Buffer)
+	buf := new(bytes.Buffer)
 	proof.Write(buf)
 
 	var got_proof IPAProof


### PR DESCRIPTION
This PR is a [second iteration](https://github.com/crate-crypto/go-ipa/pull/33) of a previous attempt to serialize points in both compressed and uncompressed forms.

In this new iteration:
- I changed the semantics of the serialization methods to have similar meanings as `master`. That is: `Bytes()` and `SetBytes()` still refer to compressed form, and there're new ones for uncompressed.
- I created a new method to transform uncompressed to compressed, which is needed now in `go-verkle` for `HashedNode` node types.

For now, I'll keep it as a draft since this branch will be needed for separate `go-verkle` and `go-ethereum` PRs.

We're doing further testing and benchmarks to confirm benchmark improvements; then, I will add some comments and open the PR.

[All this work is part of improving the replay benchmark in go-ethereum.](https://github.com/gballet/go-ethereum/pull/164)