### PR TITLE
proof verification: batch helper scalar inverses

### DIFF
--- a/multiproof.go
+++ b/multiproof.go
@@ -141,9 +141,6 @@ func CheckMultiProof(transcript *common.Transcript, ipaConf *ipa.IPAConfig, proo
 	t := transcript.ChallengeScalar("t")
 
 	// Compute helper_scalars. This is r^i / t - z_i
-	//
-	// There are more optimal ways to do this, but
-	// this is more readable, so will leave for now
 	helper_scalars := make([]fr.Element, num_queries)
 	for i := 0; i < num_queries; i++ {
 		var z = domainToFr(zs[i])

--- a/multiproof.go
+++ b/multiproof.go
@@ -146,12 +146,12 @@ func CheckMultiProof(transcript *common.Transcript, ipaConf *ipa.IPAConfig, proo
 	// this is more readable, so will leave for now
 	helper_scalars := make([]fr.Element, num_queries)
 	for i := 0; i < num_queries; i++ {
-		r := powers_of_r[i]
-
-		// r^i / (t - z_i)
 		var z = domainToFr(zs[i])
 		helper_scalars[i].Sub(&t, &z)
-		helper_scalars[i].Inverse(&helper_scalars[i])
+	}
+	helper_scalars = fr.BatchInvert(helper_scalars)
+	for i := 0; i < num_queries; i++ {
+		r := powers_of_r[i]
 		helper_scalars[i].Mul(&helper_scalars[i], &r)
 	}
 


### PR DESCRIPTION
This PR batches inverses of `(t - z_i)` when calculating helper scalars.