### PR TITLE
proof verification: use MSM for calculating E

### DIFF
--- a/ipa/config.go
+++ b/ipa/config.go
@@ -44,7 +44,7 @@ func NewIPASettingsWithSRSPrecomp(srs_precomp *SRSPrecompPoints) *IPAConfig {
 	}
 }
 
-func multiScalar(points []banderwagon.Element, scalars []fr.Element) banderwagon.Element {
+func MultiScalar(points []banderwagon.Element, scalars []fr.Element) banderwagon.Element {
 	var result banderwagon.Element
 	result.Identity()
 
@@ -69,7 +69,7 @@ func commit(group_elements []banderwagon.Element, polynomial []fr.Element) bande
 	if len(group_elements) != len(polynomial) {
 		panic(fmt.Sprintf("diff sizes, %d != %d", len(group_elements), len(polynomial)))
 	}
-	return multiScalar(group_elements, polynomial)
+	return MultiScalar(group_elements, polynomial)
 }
 
 // Computes the inner product of a and b

--- a/ipa/verifier.go
+++ b/ipa/verifier.go
@@ -57,7 +57,7 @@ func CheckIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment band
 		}
 		foldingScalars[i] = scalar
 	}
-	g0 := multiScalar(g, foldingScalars)
+	g0 := MultiScalar(g, foldingScalars)
 	b0 := InnerProd(b, foldingScalars)
 
 	var got banderwagon.Element

--- a/multiproof.go
+++ b/multiproof.go
@@ -164,13 +164,11 @@ func CheckMultiProof(transcript *common.Transcript, ipaConf *ipa.IPAConfig, proo
 	}
 
 	// Compute E = SUM C_i * (r^i / t - z_i) = SUM C_i * helper_scalars
-	var E banderwagon.Element
-	E.Identity()
-	for i := 0; i < num_queries; i++ {
-		var tmp banderwagon.Element
-		tmp.ScalarMul(Cs[i], &helper_scalars[i])
-		E.Add(&E, &tmp)
+	Csnp := make([]banderwagon.Element, len(Cs))
+	for i := 0; i < len(Cs); i++ {
+		Csnp[i] = *Cs[i]
 	}
+	E := ipa.MultiScalar(Csnp, helper_scalars)
 	transcript.AppendPoint(&E, "E")
 
 	var E_minus_D banderwagon.Element


### PR DESCRIPTION
Previously we were doing the sume of scalar multiplications for calculating `E`, instead of using a multiscalar multiplication algorithm.