### PR TITLE
proof generation: batch normalize commitments for efficient transcript appending

### DIFF
--- a/banderwagon/element.go
+++ b/banderwagon/element.go
@@ -42,6 +42,24 @@ func (p Element) Bytes() [sizePointCompressed]byte {
 	return x.Bytes()
 }
 
+func BatchNormalize(elements []*Element) {
+	// Collect all z co-ordinates
+	zs := make([]fp.Element, len(elements))
+	for i := 0; i < int(len(elements)); i++ {
+		zs[i] = elements[i].inner.Z
+	}
+
+	// Invert z co-ordinates
+	zInvs := fp.BatchInvert(zs)
+
+	// Multiply x and y by zInv
+	for i, e := range elements {
+		e.inner.X.Mul(&e.inner.X, &zInvs[i])
+		e.inner.Y.Mul(&e.inner.Y, &zInvs[i])
+		e.inner.Z = fp.One()
+	}
+}
+
 // Serialises multiple group elements using a batch multi inversion
 func ElementsToBytes(elements []*Element) [][sizePointCompressed]byte {
 	// Collect all z co-ordinates

--- a/multiproof.go
+++ b/multiproof.go
@@ -32,6 +32,7 @@ func CreateMultiProof(transcript *common.Transcript, ipaConf *ipa.IPAConfig, Cs 
 		panic("cannot create a multiproof with 0 queries")
 	}
 
+	banderwagon.BatchNormalize(Cs)
 	for i := 0; i < num_queries; i++ {
 		transcript.AppendPoint(Cs[i], "C")
 		var z = domainToFr(zs[i])


### PR DESCRIPTION
This PR creates a new helper method, `BatchNormalize([]*Element)` which is now used when generating a multiproof.

The reason is that the list `Cs` are projective points, thus when iterating over them and adding them to the transcript, the underlying `.Bytes()` will have to normalize them. That means a linear number of field inversions.

What we do now leverage the new `BatchNormalize(...)` method to normalize the projective points so when they're added to the transcript, the underlying `.Bytes()` (converting to affine) will go into fast paths avoiding inversions.

Note this situation happens for proof generation since the client has a point already in memory. For verifiers, this shouldn't be a problem since they would probably have the points in projective but deserialized from the proof, which is already normalized.