### PR TITLE
multiproof/prover: aggregate polynomials by evaluation point

### DIFF
--- a/ipa/barycentric.go
+++ b/ipa/barycentric.go
@@ -101,7 +101,7 @@ func computeBarycentricWeightForElement(element uint64) fr.Element {
 // This can also be seen as the lagrange coefficients L_i(point)
 func (preComp *PrecomputedWeights) ComputeBarycentricCoefficients(point fr.Element) []fr.Element {
 
-	// Compute A(x_i) * point - x_i
+	// Compute A'(x_i) * (point - x_i)
 	lagrangeEvals := make([]fr.Element, DOMAIN_SIZE)
 	for i := uint64(0); i < DOMAIN_SIZE; i++ {
 		weight := preComp.barycentricWeights[i]

--- a/ipa/verifier.go
+++ b/ipa/verifier.go
@@ -24,6 +24,7 @@ func CheckIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment band
 
 	w := transcript.ChallengeScalar("w")
 
+	// Rescaling of q.
 	var q banderwagon.Element
 	q.ScalarMul(&ic.SRSPrecompPoints.Q, &w)
 

--- a/multiproof.go
+++ b/multiproof.go
@@ -46,21 +46,33 @@ func CreateMultiProof(transcript *common.Transcript, ipaConf *ipa.IPAConfig, Cs 
 	r := transcript.ChallengeScalar("r")
 	powers_of_r := common.PowersOf(r, num_queries)
 
-	// Compute g(X)
-	g_x := make([]fr.Element, common.POLY_DEGREE)
-
+	// Compute g(x)
+	// We first compute the polynomials in lagrange form grouped by evaluation point, and
+	// then we compute g(X). This limit the numbers of DivideOnDomain() calls up to
+	// the domain size.
+	groupedFs := make([][]fr.Element, common.POLY_DEGREE)
 	for i := 0; i < num_queries; i++ {
-		f := fs[i]
-		index := zs[i]
+		z := zs[i]
+		if len(groupedFs[z]) == 0 {
+			groupedFs[z] = make([]fr.Element, common.POLY_DEGREE)
+		}
+
 		r := powers_of_r[i]
-
-		quotient := ipaConf.PrecomputedWeights.DivideOnDomain(index, f)
-
 		for j := 0; j < common.POLY_DEGREE; j++ {
-			var tmp fr.Element
-
-			tmp.Mul(&r, &quotient[j])
-			g_x[j].Add(&g_x[j], &tmp)
+			var scaledEvaluation fr.Element
+			scaledEvaluation.Mul(&r, &fs[i][j])
+			groupedFs[z][j].Add(&groupedFs[z][j], &scaledEvaluation)
+		}
+	}
+	g_x := make([]fr.Element, common.POLY_DEGREE)
+	for index, f := range groupedFs {
+		// If there is no polynomial for this evaluation point, we skip it.
+		if len(f) == 0 {
+			continue
+		}
+		quotient := ipaConf.PrecomputedWeights.DivideOnDomain(uint8(index), f)
+		for j := 0; j < common.POLY_DEGREE; j++ {
+			g_x[j].Add(&g_x[j], &quotient[j])
 		}
 	}
 
@@ -69,27 +81,32 @@ func CreateMultiProof(transcript *common.Transcript, ipaConf *ipa.IPAConfig, Cs 
 	transcript.AppendPoint(&D, "D")
 	t := transcript.ChallengeScalar("t")
 
-	// Compute h(X) = g_1(X)
-	h_x := make([]fr.Element, common.POLY_DEGREE)
-
-	den_inv := make([]fr.Element, num_queries)
-	for i := 0; i < num_queries; i++ {
-		var z = domainToFr(zs[i])
-		den_inv[i].Sub(&t, &z)
+	// Calculate the denominator inverses only for referenced evaluation points.
+	den_inv := make([]fr.Element, 0, common.POLY_DEGREE)
+	for z, f := range groupedFs {
+		if len(f) == 0 {
+			continue
+		}
+		var z = domainToFr(uint8(z))
+		var den fr.Element
+		den.Sub(&t, &z)
+		den_inv = append(den_inv, den)
 	}
 	den_inv = fr.BatchInvert(den_inv)
-	for i := 0; i < num_queries; i++ {
-		r := powers_of_r[i]
-		f := fs[i]
 
+	// Compute h(X) = g_1(X)
+	h_x := make([]fr.Element, common.POLY_DEGREE)
+	denInvIdx := 0
+	for _, f := range groupedFs {
+		if len(f) == 0 {
+			continue
+		}
 		for k := 0; k < common.POLY_DEGREE; k++ {
-			f_k := f[k]
-
 			var tmp fr.Element
-			tmp.Mul(&r, &f_k)
-			tmp.Mul(&tmp, &den_inv[i])
+			tmp.Mul(&f[k], &den_inv[denInvIdx])
 			h_x[k].Add(&h_x[k], &tmp)
 		}
+		denInvIdx++
 	}
 
 	h_minus_g := make([]fr.Element, common.POLY_DEGREE)


### PR DESCRIPTION
This PR applies a good idea from from the [Rust implementation](https://github.com/crate-crypto/ipa_multipoint/blob/develop/src/multiproof.rs#L140).

We first aggregate the polynomials by evaluation point, and then apply the usual protocol. This avoids unnecessary heavy work in the same evaluation point.
