### PR TITLE
multiproof:  bug fix, we always need (t-z_i) inverses

### DIFF
--- a/multiproof.go
+++ b/multiproof.go
@@ -175,9 +175,6 @@ func CheckMultiProof(transcript *common.Transcript, ipaConf *ipa.IPAConfig, proo
 	// Compute helper_scalar_den. This is 1 / t - z_i
 	helper_scalar_den := make([]fr.Element, common.POLY_DEGREE)
 	for i := 0; i < common.POLY_DEGREE; i++ {
-		if groupedEvals[i].IsZero() {
-			continue
-		}
 		// (t - z_i)
 		var z = domainToFr(uint8(i))
 		helper_scalar_den[i].Sub(&t, &z)


### PR DESCRIPTION
This PR fixes a bug identified by running `go-verkle` compatibility tests with Rust.
After digging, the reason was quite simple, to be explained in comments.

This doesn't change our performance gains since, in the worst case (which is a weird case), it adds a constant number of potential extra values to already batched inverses. I reran the benchmarks to double-check, and the verification time numbers are the same.

With this fix, `go-verkle` using this branch passes all the tests correctly. :)