### PR TITLE
Remove panics

### DIFF
--- a/bandersnatch/fr/element.go
+++ b/bandersnatch/fr/element.go
@@ -793,6 +793,9 @@ func (z *Element) SetString(s string) *Element {
 	vv := bigIntPool.Get().(*big.Int)
 
 	if _, ok := vv.SetString(s, 10); !ok {
+		// TODO: reevaluate this `panic`. Since it's from generated code
+		// is still on-hold to be removed depending if we regenerate Fr again
+		// with gnark-goff.
 		panic("Element.SetString failed -> can't parse number in base10 into a big.Int")
 	}
 	z.SetBigInt(vv)

--- a/banderwagon/element.go
+++ b/banderwagon/element.go
@@ -253,9 +253,9 @@ func (p Element) MapToScalarField(res *fr.Element) {
 }
 
 // BatchMapToScalarField maps a slice of group elements to the scalar field.
-func BatchMapToScalarField(result []*fr.Element, elements []*Element) {
+func BatchMapToScalarField(result []*fr.Element, elements []*Element) error {
 	if len(result) != len(elements) {
-		panic("MultiMapToScalarField expects the result slice to be the same length of elements")
+		return errors.New("result and elements slices must be the same length")
 	}
 
 	// Collect all y co-ordinates
@@ -275,6 +275,8 @@ func BatchMapToScalarField(result []*fr.Element, elements []*Element) {
 		byts := fp.BytesLE(mappedElement)
 		result[i].SetBytesLE(byts[:])
 	}
+
+	return nil
 }
 
 // Equal returns true if p and other represent the same point.

--- a/banderwagon/element_test.go
+++ b/banderwagon/element_test.go
@@ -37,7 +37,7 @@ func TestEncodingFixedVectors(t *testing.T) {
 	for i := 0; i < 16; i++ {
 		byts := point.Bytes()
 		if expected_bit_strings[i] != hex.EncodeToString(byts[:]) {
-			panic("bit string does not match expected")
+			t.Fatal("bit string does not match expected")
 		}
 		points = append(points, point)
 		point.Double(&point)
@@ -47,17 +47,17 @@ func TestEncodingFixedVectors(t *testing.T) {
 	for i, bit_string := range expected_bit_strings {
 		bytes, err := hex.DecodeString(bit_string)
 		if err != nil {
-			panic("could not decode bit string")
+			t.Fatal("could not decode bit string")
 		}
 
 		var element Element
 		err = element.SetBytes(bytes)
 		if err != nil {
-			panic("point was decoded as invalid")
+			t.Fatal("could not decode bit string")
 		}
 
 		if !element.Equal(&points[i]) {
-			panic("decoded element is different to expected element")
+			t.Fatal("decoded element is different to expected element")
 		}
 	}
 }
@@ -81,13 +81,13 @@ func TestTwoTorsionEqual(t *testing.T) {
 		point_plus_torsion.Add(&point, &two_torsion)
 
 		if !point.Equal(&point_plus_torsion) {
-			panic("points that differ by an order-2 point should be equal")
+			t.Fatal("points that differ by an order-2 point should be equal")
 		}
 
 		expected_bit_string := point.Bytes()
 		got_bit_string := point_plus_torsion.Bytes()
 		if expected_bit_string != got_bit_string {
-			panic("points that differ by an order-2 point should produce the same bit string")
+			t.Fatal("points that differ by an order-2 point should produce the same bit string")
 		}
 
 		point.Double(&point)
@@ -122,12 +122,12 @@ func TestPointAtInfinityComponent(t *testing.T) {
 		var element Element
 		byts, err := hex.DecodeString(bad_byte_string)
 		if err != nil {
-			panic("malformed byte string")
+			t.Fatal("could not decode bit string")
 		}
 
 		err = element.SetBytes(byts)
 		if err == nil {
-			panic("point should not be in the correct subgroup as it has an infinity component")
+			t.Fatal("point should not be in the correct subgroup as it has an infinity component")
 		}
 	}
 }
@@ -141,16 +141,16 @@ func TestAddSubDouble(t *testing.T) {
 	B.Double(&Generator)
 
 	if A.Equal(&Generator) {
-		panic("The generator should not have order < 2 ")
+		t.Fatal("The generator should not have order < 2")
 	}
 
 	if !A.Equal(&B) {
-		panic("doubling formula does not match Add formula")
+		t.Fatal("Add and Double formulae do not match")
 	}
 
 	A.Sub(&A, &B)
 	if !A.Equal(&Identity) {
-		panic("sub formula is incorrect; any point minus itself should give the identity point")
+		t.Fatal("Sub formula is incorrect; any point minus itself should give the identity point")
 	}
 }
 
@@ -166,10 +166,13 @@ func TestSerde(t *testing.T) {
 	var buf bytes.Buffer
 
 	bandersnatch.WriteUncompressedPoint(&buf, &point_aff)
-	got := bandersnatch.ReadUncompressedPoint(&buf)
+	got, err := bandersnatch.ReadUncompressedPoint(&buf)
+	if err != nil {
+		t.Fatal("could not read uncompressed point")
+	}
 
 	if !point_aff.Equal(&got) {
-		panic("deserialised point does not equal serialised point ")
+		t.Fatal("deserialised point does not equal serialised point ")
 	}
 }
 
@@ -189,10 +192,10 @@ func TestBatchElementsToBytes(t *testing.T) {
 	got_serialised_a := serialised_points[0]
 	got_serialised_b := serialised_points[1]
 	if expected_serialised_a != got_serialised_a {
-		panic("expected serialised point of A is incorrect ")
+		t.Fatal("expected serialised point of A is incorrect ")
 	}
 	if expected_serialised_b != got_serialised_b {
-		panic("expected serialised point of B is incorrect ")
+		t.Fatal("expected serialised point of B is incorrect ")
 	}
 }
 
@@ -216,11 +219,11 @@ func TestMultiMapToBaseField(t *testing.T) {
 	got_a := scalars[0]
 	got_b := scalars[1]
 	if !expected_a.Equal(got_a) {
-		panic("expected scalar for point `A` is incorrect ")
+		t.Fatal("expected scalar for point `A` is incorrect ")
 	}
 
 	if !expected_b.Equal(got_b) {
-		panic("expected scalar for point `A` is incorrect ")
+		t.Fatal("expected scalar for point `A` is incorrect ")
 	}
 }
 

--- a/common/common.go
+++ b/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/crate-crypto/go-ipa/bandersnatch/fr"
@@ -28,36 +29,25 @@ func PowersOf(x fr.Element, degree int) []fr.Element {
 	return result
 }
 
-func ReadPoint(r io.Reader) *banderwagon.Element {
+func ReadPoint(r io.Reader) (*banderwagon.Element, error) {
 	var x = make([]byte, 32)
-	n, err := r.Read(x)
-	if err != nil {
-		panic("error reading bytes")
-	}
-	if n != 32 {
-		panic("did not read enough bytes")
+	if _, err := io.ReadAtLeast(r, x, 32); err != nil {
+		return nil, fmt.Errorf("reading x coordinate: %w", err)
 	}
 	var p = &banderwagon.Element{}
-	err = p.SetBytes(x)
-	if err != nil {
-		panic("could not deserialize point")
+	if err := p.SetBytes(x); err != nil {
+		return nil, fmt.Errorf("deserializing point: %w", err)
 	}
-	return p
+	return p, nil
 }
 
-func ReadScalar(r io.Reader) *fr.Element {
+func ReadScalar(r io.Reader) (*fr.Element, error) {
 	var x = make([]byte, 32)
-	n, err := r.Read(x)
-	if err != nil {
-		panic("error reading bytes")
-	}
-	if n != 32 {
-		panic("did not read enough bytes")
+	if _, err := io.ReadAtLeast(r, x, 32); err != nil {
+		return nil, fmt.Errorf("reading scalar: %w", err)
 	}
 	var scalar = &fr.Element{}
 	scalar.SetBytesLE(x)
-	if err != nil {
-		panic("could not deserialize point")
-	}
-	return scalar
+
+	return scalar, nil
 }

--- a/common/transcript_test.go
+++ b/common/transcript_test.go
@@ -16,7 +16,7 @@ func TestVector0(t *testing.T) {
 	challenge_2 := tr.ChallengeScalar("simple_challenge")
 
 	if challenge_1 == challenge_2 {
-		panic("calling ChallengeScalar twice should yield two different challenges")
+		t.Fatal("calling ChallengeScalar twice should yield two different challenges")
 	}
 }
 func TestVector1(t *testing.T) {
@@ -29,7 +29,7 @@ func TestVector1(t *testing.T) {
 	expected := "c2aa02607cbdf5595f00ee0dd94a2bbff0bed6a2bf8452ada9011eadb538d003"
 	got := hex.EncodeToString(c_bytes[:])
 	if expected != got {
-		panic("computed challenge scalar is incorrect")
+		t.Fatal("computed challenge scalar is incorrect")
 	}
 }
 func TestVector2(t *testing.T) {
@@ -48,7 +48,7 @@ func TestVector2(t *testing.T) {
 	expected := "498732b694a8ae1622d4a9347535be589e4aee6999ffc0181d13fe9e4d037b0b"
 	got := hex.EncodeToString(c_bytes[:])
 	if expected != got {
-		panic("computed challenge scalar is incorrect")
+		t.Fatal("computed challenge scalar is incorrect")
 	}
 }
 func TestVector3(t *testing.T) {
@@ -70,7 +70,7 @@ func TestVector3(t *testing.T) {
 	expected := "14f59938e9e9b1389e74311a464f45d3d88d8ac96adf1c1129ac466de088d618"
 	got := hex.EncodeToString(c_bytes[:])
 	if expected != got {
-		panic("computed challenge scalar is incorrect")
+		t.Fatal("computed challenge scalar is incorrect")
 	}
 }
 func TestVector4(t *testing.T) {
@@ -87,6 +87,6 @@ func TestVector4(t *testing.T) {
 	expected := "8c2dafe7c0aabfa9ed542bb2cbf0568399ae794fc44fdfd7dff6cc0e6144921c"
 	got := hex.EncodeToString(c_bytes[:])
 	if expected != got {
-		panic("computed challenge scalar is incorrect")
+		t.Fatal("computed challenge scalar is incorrect")
 	}
 }

--- a/ipa/barycentric_test.go
+++ b/ipa/barycentric_test.go
@@ -122,7 +122,10 @@ func TestComputeBarycentricCoefficients(t *testing.T) {
 
 	preComp := NewPrecomputedWeights()
 	bar_coeffs := preComp.ComputeBarycentricCoefficients(point_outside_domain)
-	got := InnerProd(lagrange_values, bar_coeffs)
+	got, err := InnerProd(lagrange_values, bar_coeffs)
+	if err != nil {
+		t.Fatalf("inner product failed: %v", err)
+	}
 	expected := evalOutsideDomain(preComp, lagrange_values, point_outside_domain)
 
 	points := Points{}

--- a/ipa/barycentric_test.go
+++ b/ipa/barycentric_test.go
@@ -14,18 +14,18 @@ func TestAbsInt(t *testing.T) {
 
 	abs, is_neg := absInt(-100)
 	if abs != 100 {
-		panic("absolute value should be 100")
+		t.Fatal("absolute value should be 100")
 	}
 	if !is_neg {
-		panic("input value was negative")
+		t.Fatal("input value was negative")
 	}
 
 	abs, is_neg = absInt(250)
 	if abs != 250 {
-		panic("absolute value should be 250")
+		t.Fatal("absolute value should be 250")
 	}
 	if is_neg {
-		panic("input value was positive")
+		t.Fatal("input value was positive")
 	}
 
 }
@@ -50,17 +50,17 @@ func TestBasicInterpolate(t *testing.T) {
 		y: fr.One(),
 	}
 	points := Points{point_a, point_b}
-	poly := points.interpolate()
+	poly := points.interpolate(t)
 
 	var rand_fr fr.Element
 	_, err := rand_fr.SetRandom()
 	if err != nil {
-		panic("could not generate a random element")
+		t.Fatal("could not generate a random element")
 	}
 	result := poly.evaluate(rand_fr)
 
 	if !result.Equal(&rand_fr) {
-		panic("result should be rand_fr, because the polynomial should be the identity polynomial")
+		t.Fatal("result should be rand_fr, because the polynomial should be the identity polynomial")
 	}
 }
 
@@ -86,13 +86,13 @@ func TestPolyDiv(t *testing.T) {
 	poly_coeff_denominator := []fr.Element{minus_one, one}
 	quotient, rem, ok := pld(poly_coeff_numerator, poly_coeff_denominator)
 	if !ok {
-		panic("poly div failed")
+		t.Fatal("poly div failed")
 	}
 
 	for _, x := range rem {
 		if !x.IsZero() {
 			fmt.Printf("%v", x)
-			panic("remainder should be zero")
+			t.Fatal("remainder should be zero")
 		}
 	}
 
@@ -100,7 +100,7 @@ func TestPolyDiv(t *testing.T) {
 	var rand_fr fr.Element
 	_, err := rand_fr.SetRandom()
 	if err != nil {
-		panic("could not get randomness")
+		t.Fatal("could not get randomness")
 	}
 	got := Poly(quotient).evaluate(rand_fr)
 
@@ -108,7 +108,7 @@ func TestPolyDiv(t *testing.T) {
 	expected.Add(&rand_fr, &minus_two)
 
 	if !expected.Equal(&got) {
-		panic("quotient is not correct")
+		t.Fatal("quotient is not correct")
 	}
 }
 
@@ -136,15 +136,15 @@ func TestComputeBarycentricCoefficients(t *testing.T) {
 		}
 		points = append(points, point)
 	}
-	poly_coeff := points.interpolate()
+	poly_coeff := points.interpolate(t)
 	expected2 := poly_coeff.evaluate(point_outside_domain)
 
 	if !expected2.Equal(&expected) {
-		panic("problem with barycentric weights")
+		t.Fatal("problem with barycentric weights")
 	}
 
 	if !expected2.Equal(&got) {
-		panic("problem with inner product")
+		t.Fatal("problem with inner product")
 	}
 }
 
@@ -222,7 +222,7 @@ func TestDivideOnDomain(t *testing.T) {
 		points = append(points, point)
 	}
 
-	numerator_poly_coeff := points.interpolate()
+	numerator_poly_coeff := points.interpolate(t)
 
 	// X - 1 (This is chosen because we know it divides perfectly into the numerator)
 	denom_poly_coeff := Poly{fr.MinusOne(), fr.One()}
@@ -236,7 +236,7 @@ func TestDivideOnDomain(t *testing.T) {
 		evaluations[i] = p.y
 	}
 	if !evaluations[index].IsZero() {
-		panic("dividing on the domain with `index` will not have a remainder of zero")
+		t.Fatal("dividing on the domain with `index` will not have a remainder of zero")
 	}
 	quotientLag := preComp.DivideOnDomain(index, evaluations)
 
@@ -245,13 +245,13 @@ func TestDivideOnDomain(t *testing.T) {
 
 	expected_quotient_coeff, rem, ok := pld(numerator_poly_coeff, denom_poly_coeff)
 	if !ok {
-		panic("polynomial division failed")
+		t.Fatal("polynomial division failed")
 	}
 
 	// Remainder should be zero
 	for _, r := range rem {
 		if !r.IsZero() {
-			panic("remainder should be zero")
+			t.Fatal("remainder should be zero")
 		}
 	}
 
@@ -260,15 +260,15 @@ func TestDivideOnDomain(t *testing.T) {
 	// (X+1)(X^253)
 	should_be_zero := Poly(expected_quotient_coeff).evaluate(fr.MinusOne())
 	if !should_be_zero.IsZero() {
-		panic("-1 is not a root, but it should be")
+		t.Fatal("-1 is not a root, but it should be")
 	}
 	should_be_zero = Poly(expected_quotient_coeff).evaluate(fr.One())
 	if should_be_zero.IsZero() {
-		panic("1 is a root, but it should not be, because we just divided by X - 1")
+		t.Fatal("1 is a root, but it should not be, because we just divided by X - 1")
 	}
 	should_be_zero = Poly(expected_quotient_coeff).evaluate(fr.Zero())
 	if !should_be_zero.IsZero() {
-		panic("0 is not a root, but it should be")
+		t.Fatal("0 is not a root, but it should be")
 	}
 
 	// Lets convert quotientLag to coefficient form
@@ -283,34 +283,34 @@ func TestDivideOnDomain(t *testing.T) {
 		}
 		quotientLagEvaluations = append(quotientLagEvaluations, point)
 	}
-	got_quotient_coeff := quotientLagEvaluations.interpolate()
+	got_quotient_coeff := quotientLagEvaluations.interpolate(t)
 
 	var rand_fr fr.Element
 	_, err := rand_fr.SetRandom()
 	if err != nil {
-		panic("could not get randomness")
+		t.Fatal("could not get randomness")
 	}
 	got_res := got_quotient_coeff.evaluate(rand_fr)
 	expected_res := Poly(expected_quotient_coeff).evaluate(rand_fr)
 
 	if !expected_res.Equal(&got_res) {
-		panic("polynomials are different")
+		t.Fatal("polynomials are different")
 	}
 
 	top_term := got_quotient_coeff[len(got_quotient_coeff)-1]
 	if !top_term.IsZero() {
-		panic("top term is not zero, degree is incorrect")
+		t.Fatal("top term is not zero, degree is incorrect")
 	}
 	got_quotient_coeff = got_quotient_coeff[:len(got_quotient_coeff)-1]
 
 	if len(expected_quotient_coeff) != len(got_quotient_coeff) {
-		panic(fmt.Sprintf("%d %d", len(expected_quotient_coeff), len(got_quotient_coeff)))
+		t.Fatalf("expected quotiend coefficients %d != got quotiend coefficients %d", len(expected_quotient_coeff), len(got_quotient_coeff))
 	}
 
 	for i := 0; i < len(expected_quotient_coeff); i++ {
 
 		if !got_quotient_coeff[i].Equal(&expected_quotient_coeff[i]) {
-			panic("polynomials are not the same")
+			t.Fatal("polynomials are not the same")
 		}
 	}
 }
@@ -334,13 +334,13 @@ func (poly Poly) evaluate(point fr.Element) fr.Element {
 	}
 	return total
 }
-func (points Points) interpolate() Poly {
+func (points Points) interpolate(t *testing.T) Poly {
 	one := fr.One()
 	zero := fr.Zero()
 
 	max_degree_plus_one := len(points)
 	if max_degree_plus_one < 2 {
-		panic("should interpolate for degree >= 1")
+		t.Fatal("should interpolate for degree >= 1")
 	}
 	coeffs := make([]fr.Element, max_degree_plus_one)
 
@@ -379,7 +379,7 @@ func (points Points) interpolate() Poly {
 				contribution = append([]fr.Element{zero}, contribution...)
 				contribution = truncate(contribution, max_degree_plus_one)
 				if max_degree_plus_one != len(mul_by_minus_x_j) {
-					panic("malformed mul_by_minus_x_j")
+					t.Fatal("malformed mul_by_minus_x_j")
 				}
 				for i := 0; i < len(contribution); i++ {
 					other := mul_by_minus_x_j[i]
@@ -391,7 +391,7 @@ func (points Points) interpolate() Poly {
 		}
 		denominator.Inverse(&denominator)
 		if denominator.IsZero() {
-			panic("denominator should not be zero")
+			t.Fatal("denominator should not be zero")
 		}
 		for i := 0; i < len(contribution); i++ {
 			tmp := contribution[i]

--- a/ipa/config.go
+++ b/ipa/config.go
@@ -47,9 +47,6 @@ func NewIPASettings() (*IPAConfig, error) {
 
 // MultiScalar computes the multi scalar multiplication of points and scalars.
 func MultiScalar(points []banderwagon.Element, scalars []fr.Element) (banderwagon.Element, error) {
-	if len(points) != len(scalars) {
-		return banderwagon.Element{}, fmt.Errorf("points and scalars length does not match, %d != %d", len(points), len(scalars))
-	}
 	var result banderwagon.Element
 	result.SetIdentity()
 
@@ -65,6 +62,14 @@ func MultiScalar(points []banderwagon.Element, scalars []fr.Element) (banderwago
 // in evaluation form using the SRS.
 func (ic *IPAConfig) Commit(polynomial []fr.Element) banderwagon.Element {
 	return ic.PrecompMSM.MSM(polynomial)
+}
+
+// commit commits to a polynomial using the input group elements
+func commit(groupElements []banderwagon.Element, polynomial []fr.Element) (banderwagon.Element, error) {
+	if len(groupElements) != len(polynomial) {
+		return banderwagon.Element{}, fmt.Errorf("group elements and polynomial are different sizes, %d != %d", len(groupElements), len(polynomial))
+	}
+	return MultiScalar(groupElements, polynomial)
 }
 
 // InnerProd computes the inner product of a and b.

--- a/ipa/config.go
+++ b/ipa/config.go
@@ -47,6 +47,9 @@ func NewIPASettings() (*IPAConfig, error) {
 
 // MultiScalar computes the multi scalar multiplication of points and scalars.
 func MultiScalar(points []banderwagon.Element, scalars []fr.Element) (banderwagon.Element, error) {
+	if len(points) != len(scalars) {
+		return banderwagon.Element{}, fmt.Errorf("points and scalars length does not match, %d != %d", len(points), len(scalars))
+	}
 	var result banderwagon.Element
 	result.SetIdentity()
 
@@ -62,14 +65,6 @@ func MultiScalar(points []banderwagon.Element, scalars []fr.Element) (banderwago
 // in evaluation form using the SRS.
 func (ic *IPAConfig) Commit(polynomial []fr.Element) banderwagon.Element {
 	return ic.PrecompMSM.MSM(polynomial)
-}
-
-// commit commits to a polynomial using the input group elements
-func commit(groupElements []banderwagon.Element, polynomial []fr.Element) (banderwagon.Element, error) {
-	if len(groupElements) != len(polynomial) {
-		return banderwagon.Element{}, fmt.Errorf("group elements and polynomial are different sizes, %d != %d", len(groupElements), len(polynomial))
-	}
-	return MultiScalar(groupElements, polynomial)
 }
 
 // InnerProd computes the inner product of a and b.

--- a/ipa/ipa_test.go
+++ b/ipa/ipa_test.go
@@ -37,9 +37,16 @@ func TestIPAProofCreateVerify(t *testing.T) {
 
 	prover_transcript := common.NewTranscript("ipa")
 
-	proof := CreateIPAProof(prover_transcript, ipaConf, prover_comm, poly, point)
+	proof, err := CreateIPAProof(prover_transcript, ipaConf, prover_comm, poly, point)
+	if err != nil {
+		t.Fatalf("could not create proof: %s", err)
+	}
+
 	lagrange_coeffs := ipaConf.PrecomputedWeights.ComputeBarycentricCoefficients(point)
-	inner_product := InnerProd(poly, lagrange_coeffs)
+	inner_product, err := InnerProd(poly, lagrange_coeffs)
+	if err != nil {
+		t.Fatalf("could not compute inner product: %s", err)
+	}
 
 	test_serialize_deserialize_proof(t, proof)
 
@@ -47,7 +54,10 @@ func TestIPAProofCreateVerify(t *testing.T) {
 	verifier_comm := prover_comm // In reality, the verifier will rebuild this themselves
 	verifier_transcript := common.NewTranscript("ipa")
 
-	ok := CheckIPAProof(verifier_transcript, ipaConf, verifier_comm, proof, point, inner_product)
+	ok, err := CheckIPAProof(verifier_transcript, ipaConf, verifier_comm, proof, point, inner_product)
+	if err != nil {
+		t.Fatalf("could not check proof: %s", err)
+	}
 	if !ok {
 		t.Fatal("inner product proof failed")
 	}
@@ -77,10 +87,16 @@ func TestIPAConsistencySimpleProof(t *testing.T) {
 	test_helper.PointEqualHex(t, prover_comm, "1b9dff8f5ebbac250d291dfe90e36283a227c64b113c37f1bfb9e7a743cdb128")
 
 	prover_transcript := common.NewTranscript("test")
-	proof := CreateIPAProof(prover_transcript, ipaConf, prover_comm, poly, input_point)
+	proof, err := CreateIPAProof(prover_transcript, ipaConf, prover_comm, poly, input_point)
+	if err != nil {
+		t.Fatalf("could not create proof: %s", err)
+	}
 
 	lagrange_coeffs := ipaConf.PrecomputedWeights.ComputeBarycentricCoefficients(input_point)
-	output_point := InnerProd(poly, lagrange_coeffs)
+	output_point, err := InnerProd(poly, lagrange_coeffs)
+	if err != nil {
+		t.Fatalf("could not compute inner product: %s", err)
+	}
 	test_helper.ScalarEqualHex(t, output_point, "4a353e70b03c89f161de002e8713beec0d740a5e20722fd5bd68b30540a33208")
 
 	// Lets check the state of the transcript, by squeezing out a challenge
@@ -95,7 +111,10 @@ func TestIPAConsistencySimpleProof(t *testing.T) {
 	verifier_comm := prover_comm // In reality, the verifier will rebuild this themselves
 	verifier_transcript := common.NewTranscript("test")
 
-	ok := CheckIPAProof(verifier_transcript, ipaConf, verifier_comm, proof, input_point, output_point)
+	ok, err := CheckIPAProof(verifier_transcript, ipaConf, verifier_comm, proof, input_point, output_point)
+	if err != nil {
+		t.Fatalf("could not check proof: %s", err)
+	}
 	if !ok {
 		t.Fatal("inner product proof failed")
 	}
@@ -133,7 +152,10 @@ func TestBasicInnerProduct(t *testing.T) {
 		b = append(b, tmp)
 	}
 
-	got := InnerProd(a, b)
+	got, err := InnerProd(a, b)
+	if err != nil {
+		t.Fatalf("could not compute inner product: %s", err)
+	}
 	expected := fr.Zero()
 
 	for i := 0; i < 10; i++ {
@@ -165,7 +187,10 @@ func TestBasicCommit(t *testing.T) {
 		}
 		a = append(a, tmp)
 	}
-	got := commit(generators, a)
+	got, err := commit(generators, a)
+	if err != nil {
+		t.Fatalf("could not compute inner product: %s", err)
+	}
 
 	total := fr.Zero()
 	for i := 0; i < 5; i++ {

--- a/ipa/ipa_test.go
+++ b/ipa/ipa_test.go
@@ -187,7 +187,7 @@ func TestBasicCommit(t *testing.T) {
 		}
 		a = append(a, tmp)
 	}
-	got, err := commit(generators, a)
+	got, err := MultiScalar(generators, a)
 	if err != nil {
 		t.Fatalf("could not compute inner product: %s", err)
 	}

--- a/ipa/ipa_test.go
+++ b/ipa/ipa_test.go
@@ -187,7 +187,7 @@ func TestBasicCommit(t *testing.T) {
 		}
 		a = append(a, tmp)
 	}
-	got, err := MultiScalar(generators, a)
+	got, err := commit(generators, a)
 	if err != nil {
 		t.Fatalf("could not compute inner product: %s", err)
 	}

--- a/ipa/prover.go
+++ b/ipa/prover.go
@@ -70,20 +70,20 @@ func CreateIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment ban
 			return IPAProof{}, fmt.Errorf("could not compute a_L*b_R inner product: %w", err)
 		}
 
-		C_L_1, err := commit(G_L, a_R)
+		C_L_1, err := MultiScalar(G_L, a_R)
 		if err != nil {
 			return IPAProof{}, fmt.Errorf("could not do G_L*a_R MSM: %w", err)
 		}
-		C_L, err := commit([]banderwagon.Element{C_L_1, q}, []fr.Element{fr.One(), z_L})
+		C_L, err := MultiScalar([]banderwagon.Element{C_L_1, q}, []fr.Element{fr.One(), z_L})
 		if err != nil {
 			return IPAProof{}, fmt.Errorf("could not do C_L_1+z_L*q MSM: %w", err)
 		}
 
-		C_R_1, err := commit(G_R, a_L)
+		C_R_1, err := MultiScalar(G_R, a_L)
 		if err != nil {
 			return IPAProof{}, fmt.Errorf("could not do G_R*a_L MSM: %w", err)
 		}
-		C_R, err := commit([]banderwagon.Element{C_R_1, q}, []fr.Element{fr.One(), z_R})
+		C_R, err := MultiScalar([]banderwagon.Element{C_R_1, q}, []fr.Element{fr.One(), z_R})
 		if err != nil {
 			return IPAProof{}, fmt.Errorf("could not do C_R_1+z_R*q MSM: %w", err)
 		}

--- a/ipa/prover.go
+++ b/ipa/prover.go
@@ -70,20 +70,20 @@ func CreateIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment ban
 			return IPAProof{}, fmt.Errorf("could not compute a_L*b_R inner product: %w", err)
 		}
 
-		C_L_1, err := MultiScalar(G_L, a_R)
+		C_L_1, err := commit(G_L, a_R)
 		if err != nil {
 			return IPAProof{}, fmt.Errorf("could not do G_L*a_R MSM: %w", err)
 		}
-		C_L, err := MultiScalar([]banderwagon.Element{C_L_1, q}, []fr.Element{fr.One(), z_L})
+		C_L, err := commit([]banderwagon.Element{C_L_1, q}, []fr.Element{fr.One(), z_L})
 		if err != nil {
 			return IPAProof{}, fmt.Errorf("could not do C_L_1+z_L*q MSM: %w", err)
 		}
 
-		C_R_1, err := MultiScalar(G_R, a_L)
+		C_R_1, err := commit(G_R, a_L)
 		if err != nil {
 			return IPAProof{}, fmt.Errorf("could not do G_R*a_L MSM: %w", err)
 		}
-		C_R, err := MultiScalar([]banderwagon.Element{C_R_1, q}, []fr.Element{fr.One(), z_R})
+		C_R, err := commit([]banderwagon.Element{C_R_1, q}, []fr.Element{fr.One(), z_R})
 		if err != nil {
 			return IPAProof{}, fmt.Errorf("could not do C_R_1+z_R*q MSM: %w", err)
 		}

--- a/ipa/prover.go
+++ b/ipa/prover.go
@@ -2,6 +2,7 @@ package ipa
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 
 	"github.com/crate-crypto/go-ipa/bandersnatch/fr"
@@ -98,22 +99,33 @@ func (ip *IPAProof) Write(w io.Writer) {
 }
 
 // Read deserializes the IPA proof from the given reader.
-func (ip *IPAProof) Read(r io.Reader) {
+func (ip *IPAProof) Read(r io.Reader) error {
 	var L []banderwagon.Element
 	for i := 0; i < 8; i++ {
-		L_i := common.ReadPoint(r)
+		L_i, err := common.ReadPoint(r)
+		if err != nil {
+			return fmt.Errorf("failed to read L[%d]: %w", i, err)
+		}
 		L = append(L, *L_i)
 	}
 	ip.L = L
 	var R []banderwagon.Element
 	for i := 0; i < 8; i++ {
-		R_i := common.ReadPoint(r)
+		R_i, err := common.ReadPoint(r)
+		if err != nil {
+			return fmt.Errorf("failed to read R[%d]: %w", i, err)
+		}
 		R = append(R, *R_i)
 	}
 	ip.R = R
 
-	A_Scalar := common.ReadScalar(r)
+	A_Scalar, err := common.ReadScalar(r)
+	if err != nil {
+		return fmt.Errorf("failed to read A_scalar: %w", err)
+	}
 	ip.A_scalar = *A_Scalar
+
+	return nil
 }
 
 // Equal checks if two IPA proofs are equal.

--- a/ipa/prover.go
+++ b/ipa/prover.go
@@ -20,11 +20,14 @@ type IPAProof struct {
 // CreateIPAProof creates an IPA proof for a committed polynomial in evaluation form.
 // `a` are the evaluation of the polynomial in the domain, and `evalPoint` represents the
 // evaluation point. The evaluation of the polynomial at such point is computed automatically.
-func CreateIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment banderwagon.Element, a []fr.Element, evalPoint fr.Element) IPAProof {
+func CreateIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment banderwagon.Element, a []fr.Element, evalPoint fr.Element) (IPAProof, error) {
 	transcript.DomainSep("ipa")
 
 	b := ic.PrecomputedWeights.ComputeBarycentricCoefficients(evalPoint)
-	inner_prod := InnerProd(a, b)
+	inner_prod, err := InnerProd(a, b)
+	if err != nil {
+		return IPAProof{}, fmt.Errorf("could not compute inner product: %w", err)
+	}
 
 	transcript.AppendPoint(&commitment, "C")
 	transcript.AppendScalar(&evalPoint, "input point")
@@ -43,20 +46,47 @@ func CreateIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment ban
 
 	for i := 0; i < int(num_rounds); i++ {
 
-		a_L, a_R := splitScalars(a)
+		a_L, a_R, err := splitScalars(a)
+		if err != nil {
+			return IPAProof{}, fmt.Errorf("could not split a scalars: %w", err)
+		}
 
-		b_L, b_R := splitScalars(b)
+		b_L, b_R, err := splitScalars(b)
+		if err != nil {
+			return IPAProof{}, fmt.Errorf("could not split b scalars: %w", err)
+		}
 
-		G_L, G_R := splitPoints(current_basis)
+		G_L, G_R, err := splitPoints(current_basis)
+		if err != nil {
+			return IPAProof{}, fmt.Errorf("could not split G points: %w", err)
+		}
 
-		z_L := InnerProd(a_R, b_L)
-		z_R := InnerProd(a_L, b_R)
+		z_L, err := InnerProd(a_R, b_L)
+		if err != nil {
+			return IPAProof{}, fmt.Errorf("could not compute a_r*b_L inner product: %w", err)
+		}
+		z_R, err := InnerProd(a_L, b_R)
+		if err != nil {
+			return IPAProof{}, fmt.Errorf("could not compute a_L*b_R inner product: %w", err)
+		}
 
-		C_L_1 := commit(G_L, a_R)
-		C_L := commit([]banderwagon.Element{C_L_1, q}, []fr.Element{fr.One(), z_L})
+		C_L_1, err := commit(G_L, a_R)
+		if err != nil {
+			return IPAProof{}, fmt.Errorf("could not do G_L*a_R MSM: %w", err)
+		}
+		C_L, err := commit([]banderwagon.Element{C_L_1, q}, []fr.Element{fr.One(), z_L})
+		if err != nil {
+			return IPAProof{}, fmt.Errorf("could not do C_L_1+z_L*q MSM: %w", err)
+		}
 
-		C_R_1 := commit(G_R, a_L)
-		C_R := commit([]banderwagon.Element{C_R_1, q}, []fr.Element{fr.One(), z_R})
+		C_R_1, err := commit(G_R, a_L)
+		if err != nil {
+			return IPAProof{}, fmt.Errorf("could not do G_R*a_L MSM: %w", err)
+		}
+		C_R, err := commit([]banderwagon.Element{C_R_1, q}, []fr.Element{fr.One(), z_R})
+		if err != nil {
+			return IPAProof{}, fmt.Errorf("could not do C_R_1+z_R*q MSM: %w", err)
+		}
 
 		L[i] = C_L
 		R[i] = C_R
@@ -69,22 +99,31 @@ func CreateIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment ban
 		xInv.Inverse(&x)
 
 		// TODO: We could use a for loop here like in the Rust code
-		a = foldScalars(a_L, a_R, x)
-		b = foldScalars(b_L, b_R, xInv)
+		a, err = foldScalars(a_L, a_R, x)
+		if err != nil {
+			return IPAProof{}, fmt.Errorf("could not fold a scalars a_L and a_R with x: %w", err)
+		}
+		b, err = foldScalars(b_L, b_R, xInv)
+		if err != nil {
+			return IPAProof{}, fmt.Errorf("could not fold b scalars b_L and b_R with xInv: %w", err)
+		}
 
-		current_basis = foldPoints(G_L, G_R, xInv)
+		current_basis, err = foldPoints(G_L, G_R, xInv)
+		if err != nil {
+			return IPAProof{}, fmt.Errorf("could not fold points G_L and G_R with xInv: %w", err)
+		}
 
 	}
 
 	if len(a) != 1 {
-		panic("length of `a` should be 1 at the end of the reduction")
+		return IPAProof{}, fmt.Errorf("length of `a` should be 1 at the end of the reduction")
 	}
 
 	return IPAProof{
 		L:        L,
 		R:        R,
 		A_scalar: a[0],
-	}
+	}, nil
 }
 
 // Write serializes the IPA proof to the given writer.

--- a/ipa/verifier.go
+++ b/ipa/verifier.go
@@ -48,7 +48,7 @@ func CheckIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment band
 		R := proof.R[i]
 
 		// TODO(jsign): remove commit(..) and just use MultiScalar?
-		commitment, err = commit([]banderwagon.Element{commitment, L, R}, []fr.Element{fr.One(), x, challengesInv[i]})
+		commitment, err = MultiScalar([]banderwagon.Element{commitment, L, R}, []fr.Element{fr.One(), x, challengesInv[i]})
 		if err != nil {
 			return false, fmt.Errorf("could not compute commitment+x*L+x^-1*R: %w", err)
 		}

--- a/ipa/verifier.go
+++ b/ipa/verifier.go
@@ -47,7 +47,7 @@ func CheckIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment band
 		L := proof.L[i]
 		R := proof.R[i]
 
-		commitment, err = MultiScalar([]banderwagon.Element{commitment, L, R}, []fr.Element{fr.One(), x, challengesInv[i]})
+		commitment, err = commit([]banderwagon.Element{commitment, L, R}, []fr.Element{fr.One(), x, challengesInv[i]})
 		if err != nil {
 			return false, fmt.Errorf("could not compute commitment+x*L+x^-1*R: %w", err)
 		}

--- a/ipa/verifier.go
+++ b/ipa/verifier.go
@@ -47,7 +47,6 @@ func CheckIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment band
 		L := proof.L[i]
 		R := proof.R[i]
 
-		// TODO(jsign): remove commit(..) and just use MultiScalar?
 		commitment, err = MultiScalar([]banderwagon.Element{commitment, L, R}, []fr.Element{fr.One(), x, challengesInv[i]})
 		if err != nil {
 			return false, fmt.Errorf("could not compute commitment+x*L+x^-1*R: %w", err)

--- a/ipa/verifier.go
+++ b/ipa/verifier.go
@@ -1,6 +1,8 @@
 package ipa
 
 import (
+	"fmt"
+
 	"github.com/crate-crypto/go-ipa/bandersnatch/fr"
 	"github.com/crate-crypto/go-ipa/banderwagon"
 	"github.com/crate-crypto/go-ipa/common"
@@ -9,14 +11,14 @@ import (
 // CheckIPAProof verifies an IPA proof for a committed polynomial in evaluation form.
 // It verifies that `proof` is a valid proof for the polynomial at the evaluation
 // point `evalPoint` with result `result`
-func CheckIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment banderwagon.Element, proof IPAProof, evalPoint fr.Element, result fr.Element) bool {
+func CheckIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment banderwagon.Element, proof IPAProof, evalPoint fr.Element, result fr.Element) (bool, error) {
 	transcript.DomainSep("ipa")
 
 	if len(proof.L) != len(proof.R) {
-		panic("L and R should be the same size")
+		return false, fmt.Errorf("vectors L and R should be the same size")
 	}
 	if len(proof.L) != int(ic.numRounds) {
-		panic("The number of points for L or R should be equal to the number of rounds")
+		return false, fmt.Errorf("the number of points for L and R should be equal to the number of rounds")
 	}
 
 	b := ic.PrecomputedWeights.ComputeBarycentricCoefficients(evalPoint)
@@ -36,15 +38,20 @@ func CheckIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment band
 	commitment.Add(&commitment, &qy)
 
 	challenges := generateChallenges(transcript, &proof)
-	challenges_inv := fr.BatchInvert(challenges)
+	challengesInv := fr.BatchInvert(challenges)
 
 	// Compute expected commitment
+	var err error
 	for i := 0; i < len(challenges); i++ {
 		x := challenges[i]
 		L := proof.L[i]
 		R := proof.R[i]
 
-		commitment = commit([]banderwagon.Element{commitment, L, R}, []fr.Element{fr.One(), x, challenges_inv[i]})
+		// TODO(jsign): remove commit(..) and just use MultiScalar?
+		commitment, err = commit([]banderwagon.Element{commitment, L, R}, []fr.Element{fr.One(), x, challengesInv[i]})
+		if err != nil {
+			return false, fmt.Errorf("could not compute commitment+x*L+x^-1*R: %w", err)
+		}
 	}
 
 	g := ic.SRS
@@ -56,13 +63,19 @@ func CheckIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment band
 
 		for challengeIdx := 0; challengeIdx < len(challenges); challengeIdx++ {
 			if i&(1<<(7-challengeIdx)) > 0 {
-				scalar.Mul(&scalar, &challenges_inv[challengeIdx])
+				scalar.Mul(&scalar, &challengesInv[challengeIdx])
 			}
 		}
 		foldingScalars[i] = scalar
 	}
-	g0 := MultiScalar(g, foldingScalars)
-	b0 := InnerProd(b, foldingScalars)
+	g0, err := MultiScalar(g, foldingScalars)
+	if err != nil {
+		return false, fmt.Errorf("could not compute g0: %w", err)
+	}
+	b0, err := InnerProd(b, foldingScalars)
+	if err != nil {
+		return false, fmt.Errorf("could not compute b0: %w", err)
+	}
 
 	var got banderwagon.Element
 	//  g0 * a + (a * b) * Q;
@@ -77,7 +90,7 @@ func CheckIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment band
 
 	got.Add(&part_1, &part_2)
 
-	return got.Equal(&commitment)
+	return got.Equal(&commitment), nil
 }
 
 func generateChallenges(transcript *common.Transcript, proof *IPAProof) []fr.Element {

--- a/multiproof.go
+++ b/multiproof.go
@@ -227,10 +227,15 @@ func (mp *MultiProof) Write(w io.Writer) {
 }
 
 // Read deserializes a multi-proof from a reader.
-func (mp *MultiProof) Read(r io.Reader) {
-	D := common.ReadPoint(r)
+func (mp *MultiProof) Read(r io.Reader) error {
+	D, err := common.ReadPoint(r)
+	if err != nil {
+		return fmt.Errorf("failed to read D: %w", err)
+	}
 	mp.D = *D
 	mp.IPA.Read(r)
+
+	return nil
 }
 
 // Equal checks if two multi-proofs are equal.


### PR DESCRIPTION
This PR main goal is to remove existing panics in the database.

The changes can be understood in two buckets:
- Panics in tests: aren't that relevant, but I've changed them to `t.Fatal(f)`.
- Panics in logic: These are the most important ones; mostly had to change some further APIs to return errors.

Only one panic is left in a codepath that doesn't (and shouldn't) happen in real code. I still think we should solve it, and I go in decent length explaining which is it and why/how.

Fixes https://github.com/crate-crypto/go-ipa/issues/12
Fixes https://github.com/crate-crypto/go-ipa/issues/4