### PR TITLE
ci: add benchmark report generation

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,31 @@
+name: Benchmarks
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  deployments: write
+
+jobs:
+  benchmark:
+    name: Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "stable"
+      - name: Run benchmark
+        run: go test ./... -run=none -bench . | tee bench_output.txt
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Go Benchmark
+          tool: 'go'
+          output-file-path: bench_output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          summary-always: true


### PR DESCRIPTION
This PR adds a GH action that generates a [historical timeline](https://crate-crypto.github.io/go-ipa/dev/bench/) and a [per-action run](https://discord.com/channels/@me/1080044502271672341/1148947438086930454) report of existing benchmarks on every merge to `master`.

We use free CI machines, so things can be somewhat noisy for activating automatic alerting without setting an absurd threshold of 40%. We can try to watch plots occasionally and see if this is useful.

I had to manually create a `gh-pages` branch to prepare a bit of the stage for the action to push the generated website to the GH pages automatically.

Context: [I've discovered a gnark-crypto perf regression](https://github.com/Consensys/gnark-crypto/pull/441) while experimenting with an idea in this repo while running benchmarks locally! I hope this automatic report can get us an earlier signal in a similar situation.