### PR TITLE
precomp: use normalized extended points

### DIFF
--- a/bandersnatch/bandersnatch.go
+++ b/bandersnatch/bandersnatch.go
@@ -97,16 +97,16 @@ func computeY(x *fp.Element, choose_largest bool) *fp.Element {
 	}
 }
 
+// PointExtendedFromProj converts a point in projective coordinates to extended coordinates.
 func PointExtendedFromProj(p *PointProj) PointExtended {
-	var paffine PointAffine
-	paffine.FromProj(p)
-
+	var pzinv fp.Element
+	pzinv.Inverse(&p.Z)
 	var z fp.Element
-	z.Mul(&paffine.X, &paffine.Y)
+	z.Mul(&p.X, &p.Y).Mul(&z, &pzinv)
 	return PointExtended{
-		X: paffine.X,
-		Y: paffine.Y,
-		Z: fp.One(),
+		X: p.X,
+		Y: p.Y,
+		Z: p.Z,
 		T: z,
 	}
 }

--- a/bandersnatch/bandersnatch.go
+++ b/bandersnatch/bandersnatch.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/consensys/gnark-crypto/ecc/bls12-381/bandersnatch"
 	gnarkbandersnatch "github.com/consensys/gnark-crypto/ecc/bls12-381/bandersnatch"
 	gnarkfr "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/crate-crypto/go-ipa/bandersnatch/fp"
@@ -118,7 +117,17 @@ type PointExtendedNormalized struct {
 	X, Y, T gnarkfr.Element
 }
 
-func ExtendedAddNormalized(p, p1 *PointExtended, p2 *PointExtendedNormalized) *bandersnatch.PointExtended {
+// Neg computes p = -p1
+func (p *PointExtendedNormalized) Neg(p1 *PointExtendedNormalized) *PointExtendedNormalized {
+	p.X.Neg(&p1.X)
+	p.Y = p1.Y
+	p.T.Neg(&p1.T)
+	return p
+}
+
+// ExtendedAddNormalized computes p = p1 + p2.
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd-2
+func ExtendedAddNormalized(p, p1 *PointExtended, p2 *PointExtendedNormalized) *gnarkbandersnatch.PointExtended {
 	var A, B, C, D, E, F, G, H, tmp gnarkfr.Element
 	A.Mul(&p1.X, &p2.X)
 	B.Mul(&p1.Y, &p2.Y)
@@ -144,12 +153,5 @@ func ExtendedAddNormalized(p, p1 *PointExtended, p2 *PointExtendedNormalized) *b
 	p.T.Mul(&E, &H)
 	p.Z.Mul(&F, &G)
 
-	return p
-}
-
-func (p *PointExtendedNormalized) Neg(p1 *PointExtendedNormalized) *PointExtendedNormalized {
-	p.X.Neg(&p1.X)
-	p.Y = p1.Y
-	p.T.Neg(&p1.T)
 	return p
 }

--- a/bandersnatch/bandersnatch.go
+++ b/bandersnatch/bandersnatch.go
@@ -126,7 +126,7 @@ func (p *PointExtendedNormalized) Neg(p1 *PointExtendedNormalized) *PointExtende
 }
 
 // ExtendedAddNormalized computes p = p1 + p2.
-// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd-2
+// https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html#addition-madd-2008-hwcd
 func ExtendedAddNormalized(p, p1 *PointExtended, p2 *PointExtendedNormalized) *gnarkbandersnatch.PointExtended {
 	var A, B, C, D, E, F, G, H, tmp gnarkfr.Element
 	A.Mul(&p1.X, &p2.X)

--- a/banderwagon/precomp.go
+++ b/banderwagon/precomp.go
@@ -108,7 +108,7 @@ func NewPrecompPoint(point Element, windowSize int) (PrecompPoint, error) {
 				windows[i][j] = curr
 				curr.Add(&curr, &base)
 			}
-			res.windows[i] = batchNormalizeExtendedPoint(windows[i])
+			res.windows[i] = batchToExtendedPointNormalized(windows[i])
 			return nil
 		})
 		point.ScalarMul(&point, &specialWindow)
@@ -196,7 +196,7 @@ func batchProjToAffine(points []bandersnatch.PointProj) []bandersnatch.PointAffi
 	return result
 }
 
-func batchNormalizeExtendedPoint(points []bandersnatch.PointExtended) []bandersnatch.PointExtendedNormalized {
+func batchToExtendedPointNormalized(points []bandersnatch.PointExtended) []bandersnatch.PointExtendedNormalized {
 	result := make([]bandersnatch.PointExtendedNormalized, len(points))
 	zeroes := make([]bool, len(points))
 	accumulator := fp.One()


### PR DESCRIPTION
*Thanks to Gottfried Herold for suggesting this change* *in a chat we had some time ago*.

This PR improves the performance of our fixed-basis MSM algorithm, which is used for most heavy cryptography operations (e.g: tree key hashing, vector commitments, etc.).

The idea is simple: use Extended points additions instead of Projective mixed additions when we aggregate the precomputed points. That saves finite-field muls, thus improving performance. It has a 50% memory cost, but considering some improvements we did a while ago (and other ideas that we can still use), it feels justified for this speedup.

The path to doing this was longer than expected since I had to do some things before to be ready for the change:

- Stop relying on generated code and directly on gnark-crypto, which already supported extended points ([PR 1](https://github.com/crate-crypto/go-ipa/pull/53), [PR 2](https://github.com/crate-crypto/go-ipa/pull/54)). [This was good since we planned to do this for a while. Less code to maintain and audit].
- After that, when I started doing this change, I detected a regression in gnark-crypto, which [I helped solve in the repo](https://github.com/Consensys/gnark-crypto/pull/441)).
- Then I realized gnark-crypto was doing unintended inversions in extended points additions, so [I helped fix that in the library](https://github.com/Consensys/gnark-crypto/pull/442)).
- Then this PR was possible!

The bottom line is that we’re saving two multiplications per group operation. (Rather than one that we expected in our chat with Gottfried).

## Benchmarks

AMD Ryzen 7 3800XT 8-Core Processor:

```jsx
name                                  old time/op    new time/op    delta
PrecompMSM/msm_length=1/precomp-16      3.39µs ± 2%    2.87µs ± 2%  -15.57%  (p=0.000 n=10+10)
PrecompMSM/msm_length=2/precomp-16      6.63µs ± 1%    5.70µs ± 1%  -14.05%  (p=0.000 n=9+9)
PrecompMSM/msm_length=4/precomp-16      13.1µs ± 1%    11.2µs ± 3%  -14.53%  (p=0.000 n=10+10)
PrecompMSM/msm_length=8/precomp-16      35.3µs ± 2%    30.7µs ± 1%  -13.11%  (p=0.000 n=10+8)
PrecompMSM/msm_length=16/precomp-16     88.8µs ± 2%    76.9µs ± 1%  -13.42%  (p=0.000 n=10+10)
PrecompMSM/msm_length=32/precomp-16      208µs ± 1%     178µs ± 1%  -14.49%  (p=0.000 n=8+8)
PrecompMSM/msm_length=64/precomp-16      451µs ± 1%     393µs ± 1%  -12.90%  (p=0.000 n=8+9)
PrecompMSM/msm_length=128/precomp-16     959µs ± 2%     831µs ± 1%  -13.40%  (p=0.000 n=10+10)
PrecompMSM/msm_length=256/precomp-16    1.98ms ± 1%    1.70ms ± 2%  -13.89%  (p=0.000 n=8+10)
```

This is an `amd64` processor, so it uses gnark-crypto assembly for bigints ops.

Rock5B (this machine has another version of the stat-compare, so you might see some diffs in magnitude symbols):

```jsx
PrecompMSM/msm_length=1/precomp-8      19.40µ ± 3%   16.87µ ± 0%  -13.06% (p=0.000 n=10)
PrecompMSM/msm_length=2/precomp-8      39.21µ ± 3%   32.30µ ± 2%  -17.63% (p=0.000 n=10)
PrecompMSM/msm_length=4/precomp-8      77.64µ ± 1%   65.43µ ± 1%  -15.73% (p=0.000 n=10)
PrecompMSM/msm_length=8/precomp-8      212.7µ ± 2%   182.4µ ± 2%  -14.25% (p=0.000 n=10)
PrecompMSM/msm_length=16/precomp-8     522.4µ ± 2%   456.2µ ± 2%  -12.67% (p=0.000 n=10)
PrecompMSM/msm_length=32/precomp-8     1.170m ± 2%   1.017m ± 2%  -13.12% (p=0.000 n=10)
PrecompMSM/msm_length=64/precomp-8     2.508m ± 3%   2.114m ± 2%  -15.71% (p=0.000 n=10)
PrecompMSM/msm_length=128/precomp-8    5.042m ± 2%   4.337m ± 2%  -13.99% (p=0.000 n=10)
PrecompMSM/msm_length=256/precomp-8    10.543m ± 2%   9.347m ± 3%  -11.35% (p=0.000 n=10)
```

This is an `arm` machine, so it doesn’t use assembly (and it has a less powerful clock).

The speedups in both cases are the same, which makes sense since this optimization mostly avoids work and is independent of whatever implementation of bigint is being used.

## Finer details

So, it turns out that I still have to include a further optimized extended point formula optimized for the case when the second point has `Z==1`, which is the case for our precomputed points. That allows us to save one extra mul from the amount used by gnark-crypto. (More about this in PR comments).

Also, I had to create a further “extended point” flavor, which I name “normalized”, since our precomputed points would have `Z==1`, so it doesn’t make sense to use gnark-crypto structs which would waste 8 bytes per precomputed point. This makes the precomp tables size to increase 50% (~110MiB) rather than 100% (~220MiB).

At some point, we can chat with the gnark team if it makes sense to add a new method with this optimized formula when `Z==1`; or add an extra `if` in the current procedure to avoid the addition. (In the latter, we’d have to double-check if the potential branch misprediction… but I doubt that might be relevant; we can measure).

TODO:
- [x] Run in Kaustinen to triple-check correctness.