### PR TITLE
multiproof: improve performance of prover and verifier

### DIFF
--- a/banderwagon/element.go
+++ b/banderwagon/element.go
@@ -387,7 +387,7 @@ func (p *Element) IsOnCurve() bool {
 
 // Normalize returns a point in affine form.
 // If the point is at infinity, returns an error.
-func (p *Element) Normalise() error {
+func (p *Element) Normalize() error {
 	if p.inner.Z.IsZero() {
 		return errors.New("can not normalize point at infinity")
 	}

--- a/banderwagon/element.go
+++ b/banderwagon/element.go
@@ -385,7 +385,7 @@ func (p *Element) IsOnCurve() bool {
 	return point_aff.IsOnCurve()
 }
 
-// Normalize returns normalizes a point to affine form.
+// Normalize returns a point in affine form.
 // If the point is at infinity, returns an error.
 func (p *Element) Normalise() error {
 	if p.inner.Z.IsZero() {

--- a/banderwagon/element.go
+++ b/banderwagon/element.go
@@ -395,9 +395,9 @@ func (p *Element) IsOnCurve() bool {
 }
 
 // IsIdentity returns true if p is the identity element.
-func (p *Element) Normalise() {
+func (p *Element) Normalise() error {
 	if p.inner.Z.IsZero() {
-		return
+		return errors.New("can not normalize point at infinity")
 	}
 
 	var point_aff bandersnatch.PointAffine
@@ -406,6 +406,8 @@ func (p *Element) Normalise() {
 	p.inner.X.Set(&point_aff.X)
 	p.inner.Y.Set(&point_aff.Y)
 	p.inner.Z.SetOne()
+
+	return nil
 }
 
 // Set sets p to p1.

--- a/banderwagon/element_test.go
+++ b/banderwagon/element_test.go
@@ -246,11 +246,18 @@ func TestBatchNormalize(t *testing.T) {
 
 		// Get expected result by normalizing them independently (i.e: usual FromProj(..) method under the hood).
 		var expectedA, expectedB, expectedC Element
-		expectedA.Set(&A).Normalise()
-		expectedB.Set(&B).Normalise()
-		expectedC.Set(&C).Normalise()
-
-		BatchNormalize([]*Element{&A, &B, &C})
+		if err := expectedA.Set(&A).Normalise(); err != nil {
+			t.Fatalf("could not normalize point A: %s", err)
+		}
+		if err := expectedB.Set(&B).Normalise(); err != nil {
+			t.Fatalf("could not normalize point A: %s", err)
+		}
+		if err := expectedC.Set(&C).Normalise(); err != nil {
+			t.Fatalf("could not normalize point A: %s", err)
+		}
+		if err := BatchNormalize([]*Element{&A, &B, &C}); err != nil {
+			t.Fatalf("could not batch normalize: %s", err)
+		}
 
 		if !A.Equal(&expectedA) {
 			t.Fatal("expected point `A` is incorrect ")
@@ -273,10 +280,16 @@ func TestBatchNormalize(t *testing.T) {
 		B.Double(&A)
 
 		var expectedA, expectedB Element
-		expectedA.Set(&A).Normalise()
-		expectedB.Set(&B).Normalise()
+		if err := expectedA.Set(&A).Normalise(); err != nil {
+			t.Fatalf("could not normalize point A: %s", err)
+		}
+		if err := expectedB.Set(&B).Normalise(); err != nil {
+			t.Fatalf("could not normalize point A: %s", err)
+		}
 
-		BatchNormalize([]*Element{&A, &A, &B, &A})
+		if err := BatchNormalize([]*Element{&A, &A, &B, &A}); err != nil {
+			t.Fatalf("could not batch normalize: %s", err)
+		}
 
 		if !A.Equal(&expectedA) {
 			t.Fatal("expected point `A` is incorrect ")
@@ -301,19 +314,15 @@ func TestBatchNormalize(t *testing.T) {
 		}
 
 		var expectedA, expectedB Element
-		expectedA.Set(&A).Normalise()
-		expectedB.Set(&B).Normalise()
-
-		BatchNormalize([]*Element{&A, &B})
-
-		if !A.Equal(&expectedA) {
-			t.Fatal("expected point `A` is incorrect ")
+		if err := expectedA.Set(&A).Normalise(); err != nil {
+			t.Fatalf("could not normalize point A: %s", err)
+		}
+		if err := expectedB.Set(&B).Normalise(); err == nil {
+			t.Fatal("points at infinity can't be normalized")
 		}
 
-		if !B.inner.X.Equal(&expectedB.inner.X) ||
-			!B.inner.Y.Equal(&expectedB.inner.Y) ||
-			!B.inner.Z.Equal(&expectedB.inner.Z) {
-			t.Fatal("expected point `B` is incorrect ")
+		if err := BatchNormalize([]*Element{&A, &B}); err == nil {
+			t.Fatal("points at infinity can't be normalized")
 		}
 	})
 }

--- a/banderwagon/element_test.go
+++ b/banderwagon/element_test.go
@@ -246,13 +246,13 @@ func TestBatchNormalize(t *testing.T) {
 
 		// Get expected result by normalizing them independently (i.e: usual FromProj(..) method under the hood).
 		var expectedA, expectedB, expectedC Element
-		if err := expectedA.Set(&A).Normalise(); err != nil {
+		if err := expectedA.Set(&A).Normalize(); err != nil {
 			t.Fatalf("could not normalize point A: %s", err)
 		}
-		if err := expectedB.Set(&B).Normalise(); err != nil {
+		if err := expectedB.Set(&B).Normalize(); err != nil {
 			t.Fatalf("could not normalize point A: %s", err)
 		}
-		if err := expectedC.Set(&C).Normalise(); err != nil {
+		if err := expectedC.Set(&C).Normalize(); err != nil {
 			t.Fatalf("could not normalize point A: %s", err)
 		}
 		if err := BatchNormalize([]*Element{&A, &B, &C}); err != nil {
@@ -280,10 +280,10 @@ func TestBatchNormalize(t *testing.T) {
 		B.Double(&A)
 
 		var expectedA, expectedB Element
-		if err := expectedA.Set(&A).Normalise(); err != nil {
+		if err := expectedA.Set(&A).Normalize(); err != nil {
 			t.Fatalf("could not normalize point A: %s", err)
 		}
-		if err := expectedB.Set(&B).Normalise(); err != nil {
+		if err := expectedB.Set(&B).Normalize(); err != nil {
 			t.Fatalf("could not normalize point A: %s", err)
 		}
 
@@ -314,10 +314,10 @@ func TestBatchNormalize(t *testing.T) {
 		}
 
 		var expectedA, expectedB Element
-		if err := expectedA.Set(&A).Normalise(); err != nil {
+		if err := expectedA.Set(&A).Normalize(); err != nil {
 			t.Fatalf("could not normalize point A: %s", err)
 		}
-		if err := expectedB.Set(&B).Normalise(); err == nil {
+		if err := expectedB.Set(&B).Normalize(); err == nil {
 			t.Fatal("points at infinity can't be normalized")
 		}
 

--- a/common/transcript.go
+++ b/common/transcript.go
@@ -22,7 +22,7 @@ func NewTranscript(label string) *Transcript {
 
 	transcript := &Transcript{
 		state: digest,
-		buff:  bytes.NewBuffer(make([]byte, 1<<20)),
+		buff:  bytes.NewBuffer(make([]byte, 0, 1024)),
 	}
 
 	return transcript

--- a/common/transcript.go
+++ b/common/transcript.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"hash"
 
@@ -12,6 +13,7 @@ import (
 // See: Fiat-Shamir
 type Transcript struct {
 	state hash.Hash
+	buff  *bytes.Buffer
 }
 
 func NewTranscript(label string) *Transcript {
@@ -20,21 +22,22 @@ func NewTranscript(label string) *Transcript {
 
 	transcript := &Transcript{
 		state: digest,
+		buff:  bytes.NewBuffer(make([]byte, 1<<20)),
 	}
 
 	return transcript
 }
 
-func (t *Transcript) AppendMessage(message []byte, label string) {
-	t.state.Write([]byte(label))
-	t.state.Write(message)
+func (t *Transcript) AppendMessage(message []byte, label []byte) {
+	t.buff.Write(label)
+	t.buff.Write(message)
 }
 
 // Appends a Scalar to the transcript
 //
 // Converts the scalar to 32 bytes, then appends it to
 // the state
-func (t *Transcript) AppendScalar(scalar *fr.Element, label string) {
+func (t *Transcript) AppendScalar(scalar *fr.Element, label []byte) {
 	tmpBytes := scalar.BytesLE()
 	t.AppendMessage(tmpBytes[:], label)
 
@@ -44,14 +47,14 @@ func (t *Transcript) AppendScalar(scalar *fr.Element, label string) {
 //
 // Compresses the Point into a 32 byte slice, then appends it to
 // the state
-func (t *Transcript) AppendPoint(point *banderwagon.Element, label string) {
+func (t *Transcript) AppendPoint(point *banderwagon.Element, label []byte) {
 	tmp_bytes := point.Bytes()
 	t.AppendMessage(tmp_bytes[:], label)
 
 }
 
-func (t *Transcript) DomainSep(label string) {
-	t.state.Write([]byte(label))
+func (t *Transcript) DomainSep(label []byte) {
+	t.buff.Write(label)
 }
 
 // Computes a challenge based off of the state of the transcript
@@ -60,9 +63,11 @@ func (t *Transcript) DomainSep(label string) {
 // scalar field
 //
 // Note that calling the transcript twice, will yield two different challenges
-func (t *Transcript) ChallengeScalar(label string) fr.Element {
+func (t *Transcript) ChallengeScalar(label []byte) fr.Element {
 	t.DomainSep(label)
 
+	t.state.Write(t.buff.Bytes())
+	t.buff.Reset()
 	// Reverse the endian so we are using little-endian
 	// SetBytes interprets the bytes in Big Endian
 	bytes := t.state.Sum(nil)

--- a/common/transcript_test.go
+++ b/common/transcript_test.go
@@ -12,8 +12,8 @@ func TestVector0(t *testing.T) {
 	t.Parallel()
 
 	tr := NewTranscript("simple_protocol")
-	challenge_1 := tr.ChallengeScalar("simple_challenge")
-	challenge_2 := tr.ChallengeScalar("simple_challenge")
+	challenge_1 := tr.ChallengeScalar([]byte("simple_challenge"))
+	challenge_2 := tr.ChallengeScalar([]byte("simple_challenge"))
 
 	if challenge_1 == challenge_2 {
 		t.Fatal("calling ChallengeScalar twice should yield two different challenges")
@@ -23,7 +23,7 @@ func TestVector1(t *testing.T) {
 	t.Parallel()
 
 	tr := NewTranscript("simple_protocol")
-	challenge := tr.ChallengeScalar("simple_challenge")
+	challenge := tr.ChallengeScalar([]byte("simple_challenge"))
 	c_bytes := challenge.BytesLE()
 
 	expected := "c2aa02607cbdf5595f00ee0dd94a2bbff0bed6a2bf8452ada9011eadb538d003"
@@ -39,10 +39,10 @@ func TestVector2(t *testing.T) {
 	five := fr.Element{}
 	five.SetUint64(5)
 
-	tr.AppendScalar(&five, "five")
-	tr.AppendScalar(&five, "five again")
+	tr.AppendScalar(&five, []byte("five"))
+	tr.AppendScalar(&five, []byte("five again"))
 
-	challenge := tr.ChallengeScalar("simple_challenge")
+	challenge := tr.ChallengeScalar([]byte("simple_challenge"))
 	c_bytes := challenge.BytesLE()
 
 	expected := "498732b694a8ae1622d4a9347535be589e4aee6999ffc0181d13fe9e4d037b0b"
@@ -58,13 +58,13 @@ func TestVector3(t *testing.T) {
 	one := fr.One()
 	minus_one := fr.MinusOne()
 
-	tr.AppendScalar(&minus_one, "-1")
-	tr.DomainSep("separate me")
-	tr.AppendScalar(&minus_one, "-1 again")
-	tr.DomainSep("separate me again")
-	tr.AppendScalar(&one, "now 1")
+	tr.AppendScalar(&minus_one, []byte("-1"))
+	tr.DomainSep([]byte("separate me"))
+	tr.AppendScalar(&minus_one, []byte("-1 again"))
+	tr.DomainSep([]byte("separate me again"))
+	tr.AppendScalar(&one, []byte("now 1"))
 
-	challenge := tr.ChallengeScalar("simple_challenge")
+	challenge := tr.ChallengeScalar([]byte("simple_challenge"))
 	c_bytes := challenge.BytesLE()
 
 	expected := "14f59938e9e9b1389e74311a464f45d3d88d8ac96adf1c1129ac466de088d618"
@@ -79,9 +79,9 @@ func TestVector4(t *testing.T) {
 	tr := NewTranscript("simple_protocol")
 
 	gen := banderwagon.Generator
-	tr.AppendPoint(&gen, "generator")
+	tr.AppendPoint(&gen, []byte("generator"))
 
-	challenge := tr.ChallengeScalar("simple_challenge")
+	challenge := tr.ChallengeScalar([]byte("simple_challenge"))
 	c_bytes := challenge.BytesLE()
 
 	expected := "8c2dafe7c0aabfa9ed542bb2cbf0568399ae794fc44fdfd7dff6cc0e6144921c"

--- a/ipa/ipa_test.go
+++ b/ipa/ipa_test.go
@@ -100,7 +100,7 @@ func TestIPAConsistencySimpleProof(t *testing.T) {
 	test_helper.ScalarEqualHex(t, output_point, "4a353e70b03c89f161de002e8713beec0d740a5e20722fd5bd68b30540a33208")
 
 	// Lets check the state of the transcript, by squeezing out a challenge
-	p_challenge := prover_transcript.ChallengeScalar("state")
+	p_challenge := prover_transcript.ChallengeScalar([]byte("state"))
 	test_helper.ScalarEqualHex(t, p_challenge, "0a81881cbfd7d7197a54ebd67ed6a68b5867f3c783706675b34ece43e85e7306")
 
 	// Note, that we can be confident that any implementation which passes the above conditions
@@ -119,7 +119,7 @@ func TestIPAConsistencySimpleProof(t *testing.T) {
 		t.Fatal("inner product proof failed")
 	}
 	//
-	v_challenge := verifier_transcript.ChallengeScalar("state")
+	v_challenge := verifier_transcript.ChallengeScalar([]byte("state"))
 	if !v_challenge.Equal(&p_challenge) {
 		t.Fatal("prover and verifier state are not the same. The proof should not have passed!")
 	}

--- a/ipa/prover.go
+++ b/ipa/prover.go
@@ -17,6 +17,17 @@ func init() {
 	maxEvalPointInsideDomain.SetUint64(common.VectorLength - 1)
 }
 
+var (
+	labelDomainSep   = []byte("ipa")
+	labelC           = []byte("C")
+	labelInputPoint  = []byte("input point")
+	labelOutputPoint = []byte("output point")
+	labelW           = []byte("w")
+	labelL           = []byte("L")
+	labelR           = []byte("R")
+	labelX           = []byte("x")
+)
+
 // IPAProof is an inner product argument proof.
 type IPAProof struct {
 	L        []banderwagon.Element
@@ -28,7 +39,7 @@ type IPAProof struct {
 // `a` are the evaluation of the polynomial in the domain, and `evalPoint` represents the
 // evaluation point. The evaluation of the polynomial at such point is computed automatically.
 func CreateIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment banderwagon.Element, a []fr.Element, evalPoint fr.Element) (IPAProof, error) {
-	transcript.DomainSep("ipa")
+	transcript.DomainSep(labelDomainSep)
 
 	b := computeBVector(ic, evalPoint)
 
@@ -37,10 +48,10 @@ func CreateIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment ban
 		return IPAProof{}, fmt.Errorf("could not compute inner product: %w", err)
 	}
 
-	transcript.AppendPoint(&commitment, "C")
-	transcript.AppendScalar(&evalPoint, "input point")
-	transcript.AppendScalar(&inner_prod, "output point")
-	w := transcript.ChallengeScalar("w")
+	transcript.AppendPoint(&commitment, labelC)
+	transcript.AppendScalar(&evalPoint, labelInputPoint)
+	transcript.AppendScalar(&inner_prod, labelOutputPoint)
+	w := transcript.ChallengeScalar(labelW)
 
 	var q banderwagon.Element
 	q.ScalarMul(&ic.Q, &w)
@@ -99,9 +110,9 @@ func CreateIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment ban
 		L[i] = C_L
 		R[i] = C_R
 
-		transcript.AppendPoint(&C_L, "L")
-		transcript.AppendPoint(&C_R, "R")
-		x := transcript.ChallengeScalar("x")
+		transcript.AppendPoint(&C_L, labelL)
+		transcript.AppendPoint(&C_R, labelR)
+		x := transcript.ChallengeScalar(labelX)
 
 		var xInv fr.Element
 		xInv.Inverse(&x)

--- a/ipa/prover.go
+++ b/ipa/prover.go
@@ -17,6 +17,23 @@ func init() {
 	maxEvalPointInsideDomain.SetUint64(common.VectorLength - 1)
 }
 
+// The following are unexported labels to be used in Fiat-Shamir during the
+// inner-product argument protocol.
+//
+// The following is a short description on how they're used in the protocol:
+// 1. Append the domain separator. (labelDomainSep)
+// 2. Append the commitment to the polynomial. (labelC)
+// 3. Append the input point. (labelInputPoint)
+// 4. Append the output point. (labelOutputPoint)
+// 5. Pull the re-scaling factor `w` to scale Q. (labelW).
+// 6. For each round of the IPA protocol:
+//    a. Append the resulting point C_L. (labelL)
+//    b. Append the resulting point C_R. (labelR)
+//    c. Pull the random scalar-field element `x`. (labelX)
+//
+// Note: this package must not mutate these label values, nor pass them to
+// parts of the code that would mutate them.
+
 var (
 	labelDomainSep   = []byte("ipa")
 	labelC           = []byte("C")

--- a/ipa/verifier.go
+++ b/ipa/verifier.go
@@ -12,7 +12,7 @@ import (
 // It verifies that `proof` is a valid proof for the polynomial at the evaluation
 // point `evalPoint` with result `result`
 func CheckIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment banderwagon.Element, proof IPAProof, evalPoint fr.Element, result fr.Element) (bool, error) {
-	transcript.DomainSep("ipa")
+	transcript.DomainSep(labelDomainSep)
 
 	if len(proof.L) != len(proof.R) {
 		return false, fmt.Errorf("vectors L and R should be the same size")
@@ -23,11 +23,11 @@ func CheckIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment band
 
 	b := computeBVector(ic, evalPoint)
 
-	transcript.AppendPoint(&commitment, "C")
-	transcript.AppendScalar(&evalPoint, "input point")
-	transcript.AppendScalar(&result, "output point")
+	transcript.AppendPoint(&commitment, labelC)
+	transcript.AppendScalar(&evalPoint, labelInputPoint)
+	transcript.AppendScalar(&result, labelOutputPoint)
 
-	w := transcript.ChallengeScalar("w")
+	w := transcript.ChallengeScalar(labelW)
 
 	// Rescaling of q.
 	var q banderwagon.Element
@@ -96,9 +96,9 @@ func generateChallenges(transcript *common.Transcript, proof *IPAProof) []fr.Ele
 
 	challenges := make([]fr.Element, len(proof.L))
 	for i := 0; i < len(proof.L); i++ {
-		transcript.AppendPoint(&proof.L[i], "L")
-		transcript.AppendPoint(&proof.R[i], "R")
-		challenges[i] = transcript.ChallengeScalar("x")
+		transcript.AppendPoint(&proof.L[i], labelL)
+		transcript.AppendPoint(&proof.R[i], labelR)
+		challenges[i] = transcript.ChallengeScalar(labelX)
 	}
 	return challenges
 }

--- a/multiproof.go
+++ b/multiproof.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 
 	"github.com/crate-crypto/go-ipa/bandersnatch/fr"
 	"github.com/crate-crypto/go-ipa/banderwagon"
@@ -43,6 +44,7 @@ func CreateMultiProof(transcript *common.Transcript, ipaConf *ipa.IPAConfig, Cs 
 	}
 
 	banderwagon.BatchNormalize(Cs)
+
 	for i := 0; i < num_queries; i++ {
 		transcript.AppendPoint(Cs[i], "C")
 		var z = domainToFr(zs[i])
@@ -54,27 +56,16 @@ func CreateMultiProof(transcript *common.Transcript, ipaConf *ipa.IPAConfig, Cs 
 		y := f[zs[i]]
 		transcript.AppendScalar(&y, "y")
 	}
+
 	r := transcript.ChallengeScalar("r")
-	powers_of_r := common.PowersOf(r, num_queries)
+	powersOfR := common.PowersOf(r, num_queries)
 
 	// Compute g(x)
 	// We first compute the polynomials in lagrange form grouped by evaluation point, and
 	// then we compute g(X). This limit the numbers of DivideOnDomain() calls up to
 	// the domain size.
-	groupedFs := make([][]fr.Element, common.VectorLength)
-	for i := 0; i < num_queries; i++ {
-		z := zs[i]
-		if len(groupedFs[z]) == 0 {
-			groupedFs[z] = make([]fr.Element, common.VectorLength)
-		}
+	groupedFs := groupPolynomialsByEvaluationPoint(fs, powersOfR, zs)
 
-		r := powers_of_r[i]
-		for j := 0; j < common.VectorLength; j++ {
-			var scaledEvaluation fr.Element
-			scaledEvaluation.Mul(&r, &fs[i][j])
-			groupedFs[z][j].Add(&groupedFs[z][j], &scaledEvaluation)
-		}
-	}
 	g_x := make([]fr.Element, common.VectorLength)
 	for index, f := range groupedFs {
 		// If there is no polynomial for this evaluation point, we skip it.
@@ -273,4 +264,56 @@ func (mp MultiProof) Equal(other MultiProof) bool {
 		return false
 	}
 	return mp.D.Equal(&other.D)
+}
+
+func groupPolynomialsByEvaluationPoint(fs [][]fr.Element, powersOfR []fr.Element, zs []uint8) [common.VectorLength][]fr.Element {
+	workersAggregations := make(chan [common.VectorLength][]fr.Element)
+
+	numWorkers := runtime.NumCPU()
+	batchSize := (len(fs) + numWorkers - 1) / numWorkers
+	for i := 0; i < numWorkers; i++ {
+		go func(start, end int) {
+			if end > len(fs) {
+				end = len(fs)
+			}
+			var groupedFs [common.VectorLength][]fr.Element
+			for i := start; i < end; i++ {
+				z := zs[i]
+				if len(groupedFs[z]) == 0 {
+					groupedFs[z] = make([]fr.Element, common.VectorLength)
+				}
+
+				for j := 0; j < common.VectorLength; j++ {
+					var scaledEvaluation fr.Element
+					scaledEvaluation.Mul(&powersOfR[i], &fs[i][j])
+					groupedFs[z][j].Add(&groupedFs[z][j], &scaledEvaluation)
+				}
+			}
+			workersAggregations <- groupedFs
+		}(i*batchSize, (i+1)*batchSize)
+	}
+
+	// Each worker has computed its own aggregation. Now we aggregate the results.
+	// This is bounded to reducing a `numWorkers` sized array of `common.VectorLength` sized arrays.
+	var groupedFs [common.VectorLength][]fr.Element
+	for i := 0; i < numWorkers; i++ {
+		workerAggregation := <-workersAggregations
+		for z := range workerAggregation {
+			if len(workerAggregation[z]) == 0 {
+				continue
+			}
+			// If this is the first time we see this evaluation point, we initialize it
+			// reusing the worker result.
+			if groupedFs[z] == nil {
+				groupedFs[z] = workerAggregation[z]
+				continue
+			}
+			// If not, we aggregate the worker result with the previous result for this evaluation.
+			for j := 0; j < common.VectorLength; j++ {
+				groupedFs[z][j].Add(&groupedFs[z][j], &workerAggregation[z][j])
+			}
+		}
+	}
+
+	return groupedFs
 }

--- a/multiproof_test.go
+++ b/multiproof_test.go
@@ -250,7 +250,7 @@ func FuzzMultiProofDeserialize(f *testing.F) {
 }
 
 func BenchmarkProofGeneration(b *testing.B) {
-	numOpenings := []int{16_000}
+	numOpenings := []int{100, 10_000, 16_000, 50_000}
 
 	// Generate
 	openings := genRandomPolynomialOpenings(numOpenings[len(numOpenings)-1])

--- a/multiproof_test.go
+++ b/multiproof_test.go
@@ -3,7 +3,11 @@ package multiproof
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
+	"math/rand"
 	"os"
+	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/crate-crypto/go-ipa/bandersnatch/fr"
@@ -243,4 +247,80 @@ func FuzzMultiProofDeserialize(f *testing.F) {
 			t.Fatalf("proof serialization does not match deserialization for Multiproof")
 		}
 	})
+}
+
+func BenchmarkProofGeneration(b *testing.B) {
+	numOpenings := []int{16_000}
+
+	// Generate
+	openings := genRandomPolynomialOpenings(numOpenings[len(numOpenings)-1])
+
+	for _, n := range numOpenings {
+		b.Run(fmt.Sprintf("numopenings=%d", n), func(b *testing.B) {
+			Cs := make([]*banderwagon.Element, n)
+			fs := make([][]fr.Element, n)
+			zs := make([]uint8, n)
+
+			for i := 0; i < n; i++ {
+				Cs[i] = &openings[i].commitment
+				fs[i] = openings[i].evaluations[:]
+				zs[i] = openings[i].evalPoint
+			}
+
+			for i := 0; i < b.N; i++ {
+				tr := common.NewTranscript("ipa")
+
+				_, err := CreateMultiProof(tr, ipaConf, Cs, fs, zs)
+				if err != nil {
+					b.Fatalf("failed to create multiproof: %s", err)
+				}
+			}
+		})
+
+	}
+
+}
+
+func genRandomPolynomialOpenings(n int) []polyOpening {
+	openings := make([]polyOpening, n)
+
+	batches := runtime.NumCPU()
+	batchSize := (n + batches - 1) / batches
+
+	var wg sync.WaitGroup
+	wg.Add(batches)
+	for i := 0; i < batches; i++ {
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < batchSize; j++ {
+				if i*batchSize+j >= n {
+					break
+				}
+				openings[i*batchSize+j] = genRandomPolynomialOpening()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	return openings
+}
+
+type polyOpening struct {
+	commitment  banderwagon.Element
+	evaluations [256]fr.Element
+	evalPoint   uint8
+}
+
+func genRandomPolynomialOpening() polyOpening {
+	var polynomialFr [256]fr.Element
+	for i := range polynomialFr {
+		polynomialFr[i].SetRandom()
+	}
+	c := ipaConf.Commit(polynomialFr[:])
+
+	return polyOpening{
+		commitment:  c,
+		evaluations: polynomialFr,
+		evalPoint:   uint8(rand.Uint32()),
+	}
 }

--- a/multiproof_test.go
+++ b/multiproof_test.go
@@ -250,7 +250,7 @@ func FuzzMultiProofDeserialize(f *testing.F) {
 }
 
 func BenchmarkProofGeneration(b *testing.B) {
-	numOpenings := []int{100, 10_000, 16_000, 50_000}
+	numOpenings := []int{16_000}
 
 	// Generate
 	openings := genRandomPolynomialOpenings(numOpenings[len(numOpenings)-1])

--- a/multiproof_test.go
+++ b/multiproof_test.go
@@ -268,7 +268,15 @@ func BenchmarkProofGeneration(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				tr := common.NewTranscript("multiproof")
 
-				if _, err := CreateMultiProof(tr, ipaConf, Cs, fs, zs); err != nil {
+				b.StopTimer()
+				Cs2 := make([]*banderwagon.Element, n)
+				for i := 0; i < n; i++ {
+					cs2 := *Cs[i]
+					Cs2[i] = &cs2
+				}
+				b.StartTimer()
+
+				if _, err := CreateMultiProof(tr, ipaConf, Cs2, fs, zs); err != nil {
 					b.Fatalf("failed to create multiproof: %s", err)
 				}
 			}

--- a/multiproof_test.go
+++ b/multiproof_test.go
@@ -103,7 +103,7 @@ func TestMultiProofConsistency(t *testing.T) {
 	}
 
 	// Lets check the state of the transcript, by squeezing out a challenge
-	p_challenge := prover_transcript.ChallengeScalar("state")
+	p_challenge := prover_transcript.ChallengeScalar([]byte("state"))
 	test_helper.ScalarEqualHex(t, p_challenge, "eee8a80357ff74b766eba39db90797d022e8d6dee426ded71234241be504d519")
 
 	// Verifier view
@@ -250,7 +250,7 @@ func FuzzMultiProofDeserialize(f *testing.F) {
 }
 
 func BenchmarkProofGeneration(b *testing.B) {
-	numOpenings := []int{100, 10_000, 16_000, 50_000, 100_000, 200_000}
+	numOpenings := []int{2_000, 16_000, 32_000, 64_000, 128_000}
 	openings := genRandomPolynomialOpenings(numOpenings[len(numOpenings)-1])
 
 	for _, n := range numOpenings {
@@ -278,7 +278,7 @@ func BenchmarkProofGeneration(b *testing.B) {
 }
 
 func BenchmarkProofVerification(b *testing.B) {
-	numOpenings := []int{100, 1_000, 10_000, 16_000, 50_000, 100_000, 200_000}
+	numOpenings := []int{2_000, 16_000, 32_000, 64_000, 128_000}
 	openings := genRandomPolynomialOpenings(numOpenings[len(numOpenings)-1])
 
 	for _, n := range numOpenings {


### PR DESCRIPTION
This PR improves the performance of the proof generator and verifier.
There were many changes that I'll describe below.

## Which are the changes?
Optimizations that improved the performance of **both** the prover and verifier:
- **Avoid a lot of Fiat-Shamir transcript allocations**: For labels, we used `strings`, which eventually needed to escape to the heap since the `Hasher` requires `[]bytes`. Also, the labels are fixed (e.g: `C`, `w`, `t`, `L`, `R`, and domain separators) which doesn't even make sense that they escape once per transcript write. (e.g: for 100k points, we'd be escaping to the heap constant strings). This could be easily fixed by defining constant and not requiring `strings` since the hasher doesn't mutate their values.
- **Include buffering in Fiat-Shamir transcript**: for many openings (i.e: >10K), we add _a lot_ of stuff to the transcript before pulling a challenge. These writes are quite short e.g: for 10k openings, we append 10k * (a commitment + an evaluation + an evaluation point) to the transcript (apart from other stuff, but this dominates), so that means more than 30k quite small writes are done to the sha256 (that acts as a random oracle). That's quite inefficient. I included a buffer where we collect all writes and flush only once to sha256 when pulling a challenge. From the FS client, it's completely irrelevant since the effects of FS writes can only be observed when pulling a new challenge. (Also, we had tests to double-check the state of the transcript, so this is tested).

The first point massively reduced the number of allocations, creating less memory garbage and thus less GC pressure for the clients. This is good for secondary order effects (i.e: GC runs less often and thus burns less CPU).

Optimizations that improved the prover (apart from the above ones):
- **Parallelize Projective to Affine for transcript commitments**: The prover receives the commitments from all the openings in projective form with `Z!=1`. This is the case since there were operations at the Verkle Tree data structure layer (e.g: updating commitments after tree writes). When including this point in the FS transcript we need to transform them to affine. Despite already batching all the inverses (e.g: for transforming 10k openings, we did one inversion and not 10k), the Montgomery trick still requires a decent amount of multiplications. All these are independent of each other, so this now was parallelized.
- **Parallelize grouping polynomials by evaluation point**: long ago I introduced in this repo a trick that @kevaundray applied in the Rust version, which is grouping the polynomials by evaluation point since the evaluation domain is bounded, which simplifies a lot of operations after. This grouping was done serially; if careful, we can parallelize it correctly. ("careful" means noticing that in the VKT, there's some bias towards evaluated points in the domain 0, 1, and 2. This isn't a big deal, but it's wrong to assume they're uniformly distributed to have good balancing).


## Prover benchmarks

(Note: 128k openings are more than double the worst-case scenario estimations, I think? We'll have more idea after some Kaustinen inspection, probably. In any case, I included this case as a wild upper bound)

Here, I show benchmarks (before/after) for the prover in two setups:
- AMD Ryzen 7 3800XT: an 8-core (16-threads), high-ish-end desktop CPU. (~400usd CPU)
- [Rock5B](https://ameridroid.com/products/rock5-model-b): a single-board computer which is probably the lowest setup we can imagine being run (not sure it will survive 4844+VKT, but is a good lowest-setup target) (~200usd for all the card (CPU+all the rest))

AMD Ryzen 7 3800XT prover:
```
name                                   old time/op    new time/op    delta
ProofGeneration/numopenings=2000-16      64.1ms ± 2%    54.3ms ± 1%   -15.38%  (p=0.000 n=10+10)
ProofGeneration/numopenings=16000-16      227ms ± 1%      81ms ± 2%   -64.14%  (p=0.000 n=9+10)
ProofGeneration/numopenings=32000-16      524ms ± 1%     108ms ± 1%   -79.43%  (p=0.000 n=9+9)
ProofGeneration/numopenings=64000-16      1.48s ± 4%     0.16s ± 2%   -89.21%  (p=0.000 n=10+9)
ProofGeneration/numopenings=128000-16     4.79s ± 3%     0.26s ± 1%   -94.55%  (p=0.000 n=10+9)

name                                   old alloc/op   new alloc/op   delta
ProofGeneration/numopenings=2000-16      5.50MB ± 0%   16.61MB ± 0%  +201.83%  (p=0.000 n=10+9)
ProofGeneration/numopenings=16000-16     8.76MB ± 0%   41.81MB ± 0%  +377.47%  (p=0.000 n=10+10)
ProofGeneration/numopenings=32000-16     12.8MB ± 0%    48.0MB ± 0%  +276.44%  (p=0.000 n=10+10)
ProofGeneration/numopenings=64000-16     21.5MB ± 0%    59.7MB ± 0%  +177.16%  (p=0.000 n=10+9)
ProofGeneration/numopenings=128000-16    38.0MB ± 0%    83.3MB ± 0%  +119.26%  (p=0.000 n=10+8)

name                                   old allocs/op  new allocs/op  delta
ProofGeneration/numopenings=2000-16       17.3k ± 0%      6.6k ± 0%   -61.76%  (p=0.000 n=10+10)
ProofGeneration/numopenings=16000-16       101k ± 0%        9k ± 0%   -91.03%  (p=0.000 n=10+7)
ProofGeneration/numopenings=32000-16       197k ± 0%        9k ± 0%   -95.36%  (p=0.000 n=10+10)
ProofGeneration/numopenings=64000-16       389k ± 0%        9k ± 0%   -97.65%  (p=0.000 n=10+9)
ProofGeneration/numopenings=128000-16      773k ± 0%        9k ± 0%   -98.82%  (p=0.000 n=10+9)
```
Notes:
- `time/op` got a massive speedup as expected due to parallelization and the FS-buffering (plus probably less allocs/GC pressure)
- `alloc (MB)/op` (i.e: total memory allocated) got a bump due to parallelization since each goroutine requires memory at the same time. In relative terms, it looks like a decent bump, but in absolute terms I don't think it is a big deal. Clients could limit this by maybe allowing them to configure the amount of parallelization, but that's a tradeoffs between speed and memory usage. Note that in the above CPU we have 16 virtual cores (e.g: see the Rock5B benchmark below; since it has 8 cores (instead of 16), it uses less memory).
- `alloc (count)/op`, this got a massive reduction. We're doing fewer allocations, meaning the GC must clean up less garbage. Note that we're generating less garbage, but using more memory. This is fine in the sense that the GC overhead is related to the amount of allocations done and not to their size.

Note: We could push further to reducing allocations, which is always an interesting dance in Go... that could mean introducing extra complexity, which I'm not convinced is justified for what we might gain. So let's try to get some signal that is worth doing.

Rock5B prover:
```
name                                  old time/op    new time/op    delta
ProofGeneration/numopenings=2000-8       367ms ± 4%     359ms ± 6%      ~     (p=0.156 n=9+10)
ProofGeneration/numopenings=16000-8      1.03s ± 2%     0.45s ± 4%   -56.23%  (p=0.000 n=10+10)
ProofGeneration/numopenings=32000-8      1.99s ± 1%     0.62s ± 3%   -68.78%  (p=0.000 n=10+10)
ProofGeneration/numopenings=64000-8      4.59s ± 1%     0.89s ± 4%   -80.58%  (p=0.000 n=10+10)
ProofGeneration/numopenings=128000-8     12.5s ± 0%      1.5s ± 2%   -87.85%  (p=0.000 n=10+10)

name                                  old alloc/op   new alloc/op   delta
ProofGeneration/numopenings=2000-8      5.52MB ± 0%   14.33MB ± 0%  +159.74%  (p=0.000 n=8+10)
ProofGeneration/numopenings=16000-8     9.18MB ± 0%   25.61MB ± 0%  +179.12%  (p=0.000 n=10+9)
ProofGeneration/numopenings=32000-8     13.3MB ± 0%    31.7MB ± 0%  +138.45%  (p=0.000 n=10+10)
ProofGeneration/numopenings=64000-8     21.5MB ± 0%    43.6MB ± 0%  +102.80%  (p=0.000 n=10+9)
ProofGeneration/numopenings=128000-8    38.0MB ± 0%    69.6MB ± 0%   +83.46%  (p=0.000 n=10+10)

name                                  old allocs/op  new allocs/op  delta
ProofGeneration/numopenings=2000-8       17.2k ± 0%      6.2k ± 0%   -63.96%  (p=0.000 n=10+10)
ProofGeneration/numopenings=16000-8       101k ± 0%        7k ± 0%   -93.14%  (p=0.000 n=10+9)
ProofGeneration/numopenings=32000-8       197k ± 0%        7k ± 0%   -96.47%  (p=0.000 n=10+10)
ProofGeneration/numopenings=64000-8       389k ± 0%        7k ± 0%   -98.21%  (p=0.000 n=10+10)
ProofGeneration/numopenings=128000-8      773k ± 0%        7k ± 0%   -99.10%  (p=0.000 n=10+10)
```

## Verifier benchmarks
AMD Ryzen 7 3800XT verifier:
```
name                                     old time/op    new time/op    delta
ProofVerification/numopenings=2000-16      13.3ms ± 2%     8.9ms ± 2%  -33.10%  (p=0.000 n=9+10)
ProofVerification/numopenings=16000-16     59.8ms ± 2%    37.2ms ± 2%  -37.88%  (p=0.000 n=10+10)
ProofVerification/numopenings=32000-16      111ms ± 1%      67ms ± 2%  -39.90%  (p=0.000 n=10+10)
ProofVerification/numopenings=64000-16      208ms ± 2%     119ms ± 2%  -42.69%  (p=0.000 n=10+9)
ProofVerification/numopenings=128000-16     392ms ± 1%     214ms ± 1%  -45.45%  (p=0.000 n=9+10)

name                                     old alloc/op   new alloc/op   delta
ProofVerification/numopenings=2000-16      1.22MB ± 0%    1.50MB ± 0%  +23.17%  (p=0.000 n=10+10)
ProofVerification/numopenings=16000-16     7.84MB ± 0%   10.11MB ± 0%  +28.97%  (p=0.000 n=9+10)
ProofVerification/numopenings=32000-16     15.4MB ± 0%    19.9MB ± 0%  +29.54%  (p=0.000 n=10+10)
ProofVerification/numopenings=64000-16     30.5MB ± 0%    39.6MB ± 0%  +29.79%  (p=0.000 n=6+10)
ProofVerification/numopenings=128000-16    60.8MB ± 0%    79.0MB ± 0%  +29.92%  (p=0.000 n=10+10)

name                                     old allocs/op  new allocs/op  delta
ProofVerification/numopenings=2000-16       13.1k ± 0%      1.0k ± 0%  -92.21%  (p=0.000 n=10+10)
ProofVerification/numopenings=16000-16      97.1k ± 0%      1.0k ± 0%  -98.96%  (p=0.000 n=10+10)
ProofVerification/numopenings=32000-16       193k ± 0%        1k ± 0%  -99.48%  (p=0.000 n=10+10)
ProofVerification/numopenings=64000-16       385k ± 0%        1k ± 0%  -99.74%  (p=0.000 n=6+10)
ProofVerification/numopenings=128000-16      769k ± 0%        1k ± 0%  -99.87%  (p=0.000 n=10+10)
```

Rock5B verifier:
```
name                                    old time/op    new time/op    delta
ProofVerification/numopenings=2000-8      79.4ms ± 8%    57.4ms ±10%  -27.76%  (p=0.000 n=10+10)
ProofVerification/numopenings=16000-8      275ms ± 5%     210ms ± 7%  -23.46%  (p=0.000 n=10+10)
ProofVerification/numopenings=32000-8      502ms ± 7%     348ms ± 4%  -30.75%  (p=0.000 n=10+10)
ProofVerification/numopenings=64000-8      907ms ± 3%     617ms ± 4%  -31.97%  (p=0.000 n=10+10)
ProofVerification/numopenings=128000-8     1.77s ± 2%     1.18s ± 2%  -33.47%  (p=0.000 n=8+10)

name                                    old alloc/op   new alloc/op   delta
ProofVerification/numopenings=2000-8      1.21MB ± 0%    1.50MB ± 0%  +23.21%  (p=0.000 n=9+9)
ProofVerification/numopenings=16000-8     7.84MB ± 0%   10.11MB ± 0%  +28.98%  (p=0.000 n=10+10)
ProofVerification/numopenings=32000-8     15.4MB ± 0%    19.9MB ± 0%  +29.55%  (p=0.000 n=9+10)
ProofVerification/numopenings=64000-8     30.5MB ± 0%    39.6MB ± 0%  +29.80%  (p=0.000 n=10+10)
ProofVerification/numopenings=128000-8    60.8MB ± 0%    79.0MB ± 0%  +29.92%  (p=0.000 n=10+10)

name                                    old allocs/op  new allocs/op  delta
ProofVerification/numopenings=2000-8       13.1k ± 0%      1.0k ± 0%  -92.44%  (p=0.000 n=10+9)
ProofVerification/numopenings=16000-8      97.0k ± 0%      1.0k ± 0%  -98.99%  (p=0.000 n=10+10)
ProofVerification/numopenings=32000-8       193k ± 0%        1k ± 0%  -99.49%  (p=0.000 n=9+10)
ProofVerification/numopenings=64000-8       385k ± 0%        1k ± 0%  -99.75%  (p=0.000 n=10+10)
ProofVerification/numopenings=128000-8      769k ± 0%        1k ± 1%  -99.87%  (p=0.000 n=10+10)
```


### Tangent: verifier vs prover speed?

I'd a personal _feeling_ that the verifier isn't _that_ faster than the prover. It's faster by double-digit %, but not incredibly faster. For the Rock5B case, the difference is a bit bigger.  e.g: for 64k the Rock5B prover takes 890ms and verifier 617ms (1.44x). For my CPU, the prover takes 160ms and verifier 119ms (1.34x). 

Taking a further look at, for example, the 100k openings case, more than half of that time is spent in an MSM of length 100k (we need this to compute `E`, i.e: the linear combination of `Cs` with powers of `r`). This is parallelized by gnark-crypto, but still is a 100k MSM which is quite massive, so I guess it makes sense. A big part of the rest is appending 100k elements to the FS-transcript (i.e: for each opening, we have to append `C`, `y` and `z`, so thats `32 bytes * 3 * 100K`, which is a decent amount of stuff to serialize and hash).

The prover is quite fast since, apart from all the tricks and now parallelization, it can do most of the stuff in the evaluation form with the "grouping by evaluation point" that we do. So no MSM is required there. (Still have to append 100k (C+y+z), too, so that's the same for both).

Anyway, this is just a comment if this was surprising for some other reader. The verifier "IPA verification" part is very fast and constant (as expected, <10ms), so most of the overhead comes from the Multiproof part that is dependent on the number of openings.

The last note is that the Go standard library implementation of sha256, doesn't leverage SIMD instructions for sha256 if available in the CPU. I think this is planned in the next version of Go. I did a test with a Go library that does that, and the FS-part gets a decent speedup; but quite honestly, I'd prefer to stick to the Go standard library of sha256 since it's quite a delicate dependency to just save a dozen of ms (tested in my CPU).

### TODOs
I'll keep this as a draft until:
- [x] I'll use a custom version of geth running this PR joining the new Kaustinen network (when ready), to double-check that things look fine. They should since we already have tests, but I'm a bit paranoid with these kinds of changes, so let's wait a bit until I can do that so I'll open when having extra "good signal".
- [x] Create PR comments to help reviewing the PR. 

