### PR TITLE
ipa: support in-domain evaluations

### DIFF
--- a/ipa/verifier.go
+++ b/ipa/verifier.go
@@ -21,7 +21,7 @@ func CheckIPAProof(transcript *common.Transcript, ic *IPAConfig, commitment band
 		return false, fmt.Errorf("the number of points for L and R should be equal to the number of rounds")
 	}
 
-	b := ic.PrecomputedWeights.ComputeBarycentricCoefficients(evalPoint)
+	b := computeBVector(ic, evalPoint)
 
 	transcript.AppendPoint(&commitment, "C")
 	transcript.AppendScalar(&evalPoint, "input point")


### PR DESCRIPTION
This PR adds handling for correctly generating proofs and verifying them if the evaluation point is inside the domain.

Technically speaking, this is a border-case of multiproofs for Verkle Trees. In Multiproofs, we use IPA to evaluate an "aggregated polynomial" at a random scalar field element via FS. This means that the chance of getting an in-domain evaluation point is `256/FrSize` which is incredibly low but still possible. 

If, by any chance, this happens in the current implementation, our prover/verifier would fail since the barycentric formula needs the assumption that the evaluation point is outside the domain.

The solution to this is straightforward and is to not really on the barycentric formula for the B vector and use a ~unity vector (i.e: [0, 0,.., 1,.., 0]). The reason this work is pretty obvious since `<a, b>` will result in the i-th value of `a` which matches the evaluation we want since we work in the evaluation form.


So, considering the fix is easy, let's just include this to handle this border-case correctly and be 100% sure there won't be cases where a proof can't be generated/verified.