### PR TITLE
mod: update gnark-crypto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/crate-crypto/go-ipa
 go 1.18
 
 require (
-	github.com/consensys/gnark-crypto v0.11.3-0.20230906172141-49815a21349a
+	github.com/consensys/gnark-crypto v0.12.1
 	github.com/leanovate/gopter v0.2.9
 	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/bits-and-blooms/bitset v1.7.0 h1:YjAGVd3XmtK9ktAbX8Zg2g2PwLIMjGREZJHl
 github.com/bits-and-blooms/bitset v1.7.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
-github.com/consensys/gnark-crypto v0.11.3-0.20230906172141-49815a21349a h1:Rc86uLASrW3xpeWRH8V9W23v5QYegI/wjgbZzwPiC44=
-github.com/consensys/gnark-crypto v0.11.3-0.20230906172141-49815a21349a/go.mod h1:v2Gy7L/4ZRosZ7Ivs+9SfUDr0f5UlG+EM5t7MPHiLuY=
+github.com/consensys/gnark-crypto v0.12.1 h1:lHH39WuuFgVHONRl3J0LRBtuYdQTumFSDtJF7HpyG8M=
+github.com/consensys/gnark-crypto v0.12.1/go.mod h1:v2Gy7L/4ZRosZ7Ivs+9SfUDr0f5UlG+EM5t7MPHiLuY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=


### PR DESCRIPTION
This PR updates `gnark-crypto`.

I did a bench comparison, and looks like there aren't any _relevant_ regressions.

Output:
```
name                                     old time/op    new time/op    delta
pkg:github.com/crate-crypto/go-ipa goos:linux goarch:amd64
ProofGeneration/numopenings=2000-16        52.4ms ± 1%    52.8ms ± 1%    ~     (p=0.151 n=5+5)
ProofGeneration/numopenings=16000-16       77.6ms ± 1%    76.9ms ± 0%    ~     (p=0.310 n=5+5)
ProofGeneration/numopenings=32000-16       98.2ms ± 1%    97.8ms ± 2%    ~     (p=0.421 n=5+5)
ProofGeneration/numopenings=64000-16        151ms ± 5%     140ms ± 3%  -7.46%  (p=0.008 n=5+5)
ProofGeneration/numopenings=128000-16       243ms ± 6%     230ms ± 1%  -5.32%  (p=0.016 n=5+5)
ProofVerification/numopenings=2000-16      8.67ms ± 2%    8.86ms ± 9%    ~     (p=1.000 n=5+5)
ProofVerification/numopenings=16000-16     36.6ms ± 2%    36.7ms ± 2%    ~     (p=0.841 n=5+5)
ProofVerification/numopenings=32000-16     66.6ms ± 3%    66.8ms ± 2%    ~     (p=0.421 n=5+5)
ProofVerification/numopenings=64000-16      120ms ± 1%     120ms ± 2%    ~     (p=0.421 n=5+5)
ProofVerification/numopenings=128000-16     222ms ± 7%     212ms ± 1%  -4.70%  (p=0.016 n=5+5)
pkg:github.com/crate-crypto/go-ipa/bandersnatch goos:linux goarch:amd64
MultiExpG1/32_points-16                     376µs ±13%     339µs ± 4%    ~     (p=0.548 n=5+5)
MultiExpG1/64_points-16                     379µs ± 2%     393µs ± 8%    ~     (p=0.548 n=5+5)
MultiExpG1/128_points-16                    489µs ± 3%     508µs ± 8%    ~     (p=0.151 n=5+5)
MultiExpG1/256_points-16                    619µs ± 3%     630µs ± 2%    ~     (p=0.222 n=5+5)
MultiExpG1/512_points-16                   1.06ms ± 4%    1.06ms ± 0%    ~     (p=0.730 n=5+4)
MultiExpG1/1024_points-16                  1.89ms ±11%    1.94ms ± 1%    ~     (p=0.556 n=5+4)
MultiExpG1/2048_points-16                  2.39ms ± 2%    2.32ms ± 1%  -2.66%  (p=0.032 n=5+5)
MultiExpG1/4096_points-16                  4.60ms ± 9%    4.50ms ±18%    ~     (p=0.548 n=5+5)
MultiExpG1/8192_points-16                  8.22ms ± 3%    8.09ms ± 2%    ~     (p=0.151 n=5+5)
MultiExpG1/16384_points-16                 16.0ms ± 2%    15.8ms ± 1%    ~     (p=0.222 n=5+5)
MultiExpG1/32768_points-16                 30.6ms ± 1%    30.3ms ± 2%    ~     (p=0.222 n=5+5)
MultiExpG1/65536_points-16                 55.4ms ± 2%    53.3ms ± 2%  -3.74%  (p=0.008 n=5+5)
MultiExpG1/131072_points-16                97.0ms ± 9%    91.3ms ± 3%  -5.81%  (p=0.032 n=5+5)
MultiExpG1/262144_points-16                 168ms ± 8%     156ms ± 3%  -7.17%  (p=0.032 n=5+5)
MultiExpG1/524288_points-16                 313ms ± 1%     310ms ± 1%    ~     (p=0.095 n=5+5)
MultiExpG1/1048576_points-16                585ms ± 1%     616ms ±17%    ~     (p=0.310 n=5+5)
MultiExpG1/2097152_points-16                1.18s ± 2%     1.19s ± 2%    ~     (p=0.421 n=5+5)
MultiExpG1/4194304_points-16                2.36s ± 2%     2.35s ± 2%    ~     (p=0.841 n=5+5)
MultiExpG1/8388608_points-16                5.32s ± 8%     5.01s ± 5%  -5.74%  (p=0.032 n=5+5)
MultiExpG1/16777216_points-16               9.07s ± 1%     9.19s ± 3%    ~     (p=0.548 n=5+5)
MultiExpG1Reference-16                      592ms ± 2%     644ms ±14%  +8.86%  (p=0.032 n=5+5)
ManyMultiExpG1Reference-16                  1.77s ± 1%     1.80s ± 4%    ~     (p=1.000 n=5+5)
pkg:github.com/crate-crypto/go-ipa/bandersnatch/fr goos:linux goarch:amd64
ElementSetBytes-16                         50.2ns ± 3%    50.0ns ± 2%    ~     (p=0.841 n=5+5)
ElementMulByConstants/mulBy3-16            5.14ns ± 4%    5.14ns ± 1%    ~     (p=0.841 n=5+5)
ElementMulByConstants/mulBy5-16            6.69ns ± 3%    6.70ns ± 1%    ~     (p=0.690 n=5+5)
ElementMulByConstants/mulBy13-16           10.0ns ± 1%    10.0ns ± 1%    ~     (p=0.730 n=5+5)
ElementInverse-16                          1.70µs ± 2%    1.69µs ± 4%    ~     (p=0.730 n=5+5)
ElementButterfly-16                        4.70ns ± 3%    4.63ns ± 1%    ~     (p=0.151 n=5+5)
ElementExp-16                              6.48µs ± 3%    6.45µs ± 3%    ~     (p=1.000 n=5+5)
ElementDouble-16                           3.37ns ± 1%    3.36ns ± 0%    ~     (p=0.317 n=5+4)
ElementAdd-16                              3.46ns ± 3%    3.45ns ± 2%    ~     (p=0.444 n=5+5)
ElementSub-16                              3.41ns ± 2%    3.41ns ± 2%    ~     (p=1.000 n=5+5)
ElementNeg-16                              2.32ns ± 2%    2.35ns ± 2%    ~     (p=0.222 n=5+5)
ElementDiv-16                              1.74µs ± 3%    1.74µs ± 2%    ~     (p=0.730 n=5+5)
ElementFromMont-16                         11.5ns ± 3%    11.7ns ± 4%    ~     (p=0.167 n=5+5)
ElementToMont-16                           15.9ns ± 1%    16.1ns ± 4%    ~     (p=0.937 n=5+5)
ElementSquare-16                           15.6ns ± 1%    15.9ns ± 1%  +2.13%  (p=0.016 n=5+5)
ElementSqrt-16                             6.28µs ± 2%    6.52µs ± 3%  +3.74%  (p=0.008 n=5+5)
ElementMul-16                              16.7ns ± 2%    16.8ns ± 1%    ~     (p=0.810 n=5+5)
ElementCmp-16                              23.9ns ± 2%    24.1ns ± 1%    ~     (p=0.548 n=5+5)
pkg:github.com/crate-crypto/go-ipa/banderwagon goos:linux goarch:amd64
PrecompMSM/msm_length=1/precomp-16         3.04µs ± 2%    3.07µs ± 0%    ~     (p=0.095 n=5+5)
PrecompMSM/msm_length=2/precomp-16         5.86µs ± 2%    5.88µs ± 2%    ~     (p=0.841 n=5+5)
PrecompMSM/msm_length=4/precomp-16         11.7µs ± 0%    11.5µs ± 2%    ~     (p=0.421 n=5+5)
PrecompMSM/msm_length=8/precomp-16         31.6µs ± 2%    31.6µs ± 2%    ~     (p=0.548 n=5+5)
PrecompMSM/msm_length=16/precomp-16        78.0µs ± 2%    80.5µs ± 1%  +3.10%  (p=0.008 n=5+5)
PrecompMSM/msm_length=32/precomp-16         183µs ± 1%     192µs ± 4%  +4.47%  (p=0.008 n=5+5)
PrecompMSM/msm_length=64/precomp-16         402µs ± 2%     416µs ± 2%  +3.44%  (p=0.008 n=5+5)
PrecompMSM/msm_length=128/precomp-16        874µs ± 1%     883µs ± 2%    ~     (p=0.151 n=5+5)
PrecompMSM/msm_length=256/precomp-16       1.73ms ± 2%    1.75ms ± 2%    ~     (p=0.310 n=5+5)
PrecompInitialize-16                        529ms ± 1%     533ms ± 1%    ~     (p=0.421 n=5+5)

name                                     old alloc/op   new alloc/op   delta
pkg:github.com/crate-crypto/go-ipa goos:linux goarch:amd64
ProofGeneration/numopenings=2000-16        16.9MB ± 0%    16.7MB ± 0%  -1.60%  (p=0.008 n=5+5)
ProofGeneration/numopenings=16000-16       41.5MB ± 0%    41.5MB ± 0%  +0.10%  (p=0.016 n=5+4)
ProofGeneration/numopenings=32000-16       48.0MB ± 0%    48.0MB ± 0%  +0.02%  (p=0.008 n=5+5)
ProofGeneration/numopenings=64000-16       59.6MB ± 0%    59.6MB ± 0%    ~     (p=0.413 n=5+4)
ProofGeneration/numopenings=128000-16      82.9MB ± 0%    82.9MB ± 0%    ~     (p=0.190 n=4+5)
ProofVerification/numopenings=2000-16      1.50MB ± 0%    1.50MB ± 0%  +0.00%  (p=0.016 n=5+5)
ProofVerification/numopenings=16000-16     10.1MB ± 0%    10.1MB ± 0%    ~     (p=0.690 n=5+5)
ProofVerification/numopenings=32000-16     19.9MB ± 0%    19.9MB ± 0%    ~     (p=0.103 n=5+5)
ProofVerification/numopenings=64000-16     39.6MB ± 0%    39.6MB ± 0%    ~     (p=0.714 n=5+5)
ProofVerification/numopenings=128000-16    79.0MB ± 0%    79.0MB ± 0%    ~     (p=0.175 n=5+4)
pkg:github.com/crate-crypto/go-ipa/bandersnatch goos:linux goarch:amd64
MultiExpG1/32_points-16                    17.6kB ± 0%    17.6kB ± 0%    ~     (p=0.921 n=5+5)
MultiExpG1/64_points-16                    20.6kB ± 0%    20.6kB ± 0%    ~     (all equal)
MultiExpG1/128_points-16                   22.6kB ± 0%    22.6kB ± 0%    ~     (all equal)
MultiExpG1/256_points-16                   23.8kB ± 0%    23.8kB ± 0%    ~     (all equal)
MultiExpG1/512_points-16                   29.8kB ± 0%    29.8kB ± 0%    ~     (all equal)
MultiExpG1/1024_points-16                  44.5kB ± 0%    44.5kB ± 0%    ~     (all equal)
MultiExpG1/2048_points-16                  76.4kB ± 0%    76.4kB ± 0%    ~     (all equal)
MultiExpG1/4096_points-16                   142kB ± 0%     142kB ± 0%    ~     (all equal)
MultiExpG1/8192_points-16                   272kB ± 0%     272kB ± 0%    ~     (all equal)
MultiExpG1/16384_points-16                  533kB ± 0%     533kB ± 0%    ~     (p=0.429 n=5+5)
MultiExpG1/32768_points-16                 1.06MB ± 0%    1.06MB ± 0%    ~     (p=1.000 n=4+5)
MultiExpG1/65536_points-16                 2.11MB ± 0%    2.11MB ± 0%    ~     (p=0.175 n=5+5)
MultiExpG1/131072_points-16                4.20MB ± 0%    4.20MB ± 0%    ~     (p=0.389 n=5+5)
MultiExpG1/262144_points-16                8.40MB ± 0%    8.40MB ± 0%    ~     (p=0.127 n=5+5)
MultiExpG1/524288_points-16                16.8MB ± 0%    16.8MB ± 0%  -0.00%  (p=0.000 n=5+4)
MultiExpG1/1048576_points-16               33.6MB ± 0%    33.6MB ± 0%    ~     (p=0.079 n=4+5)
MultiExpG1/2097152_points-16               67.1MB ± 0%    67.1MB ± 0%  -0.00%  (p=0.029 n=4+4)
MultiExpG1/4194304_points-16                134MB ± 0%     134MB ± 0%    ~     (p=0.556 n=5+4)
MultiExpG1/8388608_points-16               1.48GB ± 0%    1.48GB ± 0%    ~     (p=0.238 n=5+4)
MultiExpG1/16777216_points-16              1.74GB ± 0%    1.74GB ± 0%    ~     (p=0.714 n=5+5)
MultiExpG1Reference-16                     33.6MB ± 0%    33.6MB ± 0%    ~     (p=0.556 n=4+5)
ManyMultiExpG1Reference-16                  101MB ± 0%     101MB ± 0%    ~     (p=0.881 n=5+5)
pkg:github.com/crate-crypto/go-ipa/bandersnatch/fr goos:linux goarch:amd64
ElementSetBytes-16                          0.00B          0.00B         ~     (all equal)
ElementMulByConstants/mulBy3-16             0.00B          0.00B         ~     (all equal)
ElementMulByConstants/mulBy5-16             0.00B          0.00B         ~     (all equal)
ElementMulByConstants/mulBy13-16            0.00B          0.00B         ~     (all equal)
ElementInverse-16                           0.00B          0.00B         ~     (all equal)
ElementButterfly-16                         0.00B          0.00B         ~     (all equal)
ElementExp-16                               0.00B          0.00B         ~     (all equal)
ElementDouble-16                            0.00B          0.00B         ~     (all equal)
ElementAdd-16                               0.00B          0.00B         ~     (all equal)
ElementSub-16                               0.00B          0.00B         ~     (all equal)
ElementNeg-16                               0.00B          0.00B         ~     (all equal)
ElementDiv-16                               0.00B          0.00B         ~     (all equal)
ElementFromMont-16                          0.00B          0.00B         ~     (all equal)
ElementToMont-16                            0.00B          0.00B         ~     (all equal)
ElementSquare-16                            0.00B          0.00B         ~     (all equal)
ElementSqrt-16                              0.00B          0.00B         ~     (all equal)
ElementMul-16                               0.00B          0.00B         ~     (all equal)
ElementCmp-16                               0.00B          0.00B         ~     (all equal)
pkg:github.com/crate-crypto/go-ipa/banderwagon goos:linux goarch:amd64
PrecompMSM/msm_length=1/precomp-16          0.00B          0.00B         ~     (all equal)
PrecompMSM/msm_length=2/precomp-16          0.00B          0.00B         ~     (all equal)
PrecompMSM/msm_length=4/precomp-16          0.00B          0.00B         ~     (all equal)
PrecompMSM/msm_length=8/precomp-16          0.00B          0.00B         ~     (all equal)
PrecompMSM/msm_length=16/precomp-16         0.00B          0.00B         ~     (all equal)
PrecompMSM/msm_length=32/precomp-16         0.00B          0.00B         ~     (all equal)
PrecompMSM/msm_length=64/precomp-16         0.00B          0.00B         ~     (all equal)
PrecompMSM/msm_length=128/precomp-16        0.00B          0.00B         ~     (all equal)
PrecompMSM/msm_length=256/precomp-16        0.00B          0.00B         ~     (all equal)
PrecompInitialize-16                        833MB ± 0%     833MB ± 0%    ~     (p=0.190 n=5+4)

name                                     old allocs/op  new allocs/op  delta
pkg:github.com/crate-crypto/go-ipa goos:linux goarch:amd64
ProofGeneration/numopenings=2000-16         6.66k ± 0%     6.63k ± 0%  -0.47%  (p=0.008 n=5+5)
ProofGeneration/numopenings=16000-16        9.05k ± 0%     9.06k ± 0%  +0.06%  (p=0.029 n=4+4)
ProofGeneration/numopenings=32000-16        9.14k ± 0%     9.14k ± 0%    ~     (p=0.246 n=5+5)
ProofGeneration/numopenings=64000-16        9.15k ± 0%     9.15k ± 0%    ~     (p=0.127 n=4+5)
ProofGeneration/numopenings=128000-16       9.16k ± 0%     9.15k ± 0%    ~     (p=0.143 n=5+5)
ProofVerification/numopenings=2000-16       1.02k ± 0%     1.02k ± 0%  +0.10%  (p=0.008 n=5+5)
ProofVerification/numopenings=16000-16      1.01k ± 0%     1.01k ± 0%  +0.16%  (p=0.008 n=5+5)
ProofVerification/numopenings=32000-16      1.01k ± 0%     1.01k ± 0%    ~     (p=0.333 n=5+4)
ProofVerification/numopenings=64000-16      1.01k ± 0%     1.01k ± 0%    ~     (p=0.683 n=5+5)
ProofVerification/numopenings=128000-16     1.01k ± 0%     1.01k ± 0%    ~     (p=1.000 n=5+4)
pkg:github.com/crate-crypto/go-ipa/bandersnatch goos:linux goarch:amd64
MultiExpG1/32_points-16                      89.0 ± 0%      89.0 ± 0%    ~     (all equal)
MultiExpG1/64_points-16                       130 ± 0%       130 ± 0%    ~     (all equal)
MultiExpG1/128_points-16                      130 ± 0%       130 ± 0%    ~     (all equal)
MultiExpG1/256_points-16                      112 ± 0%       112 ± 0%    ~     (all equal)
MultiExpG1/512_points-16                      100 ± 0%       100 ± 0%    ~     (all equal)
MultiExpG1/1024_points-16                    89.0 ± 0%      89.0 ± 0%    ~     (all equal)
MultiExpG1/2048_points-16                    84.0 ± 0%      84.0 ± 0%    ~     (all equal)
MultiExpG1/4096_points-16                    84.0 ± 0%      84.0 ± 0%    ~     (all equal)
MultiExpG1/8192_points-16                    78.0 ± 0%      78.0 ± 0%    ~     (all equal)
MultiExpG1/16384_points-16                   74.0 ± 0%      74.0 ± 0%    ~     (all equal)
MultiExpG1/32768_points-16                   70.0 ± 0%      70.0 ± 0%    ~     (all equal)
MultiExpG1/65536_points-16                   66.0 ± 0%      66.0 ± 0%    ~     (all equal)
MultiExpG1/131072_points-16                  64.0 ± 0%      64.0 ± 0%    ~     (all equal)
MultiExpG1/262144_points-16                  62.0 ± 0%      62.0 ± 0%    ~     (all equal)
MultiExpG1/524288_points-16                  57.0 ± 0%      57.0 ± 0%    ~     (all equal)
MultiExpG1/1048576_points-16                 57.0 ± 0%      57.0 ± 0%    ~     (all equal)
MultiExpG1/2097152_points-16                 58.0 ± 0%      57.0 ± 0%  -1.72%  (p=0.029 n=4+4)
MultiExpG1/4194304_points-16                 93.6 ± 1%      94.0 ± 0%    ~     (p=0.556 n=5+4)
MultiExpG1/8388608_points-16                  107 ± 1%       108 ± 0%    ~     (p=0.238 n=5+4)
MultiExpG1/16777216_points-16                 111 ± 3%       111 ± 8%    ~     (p=0.357 n=5+5)
MultiExpG1Reference-16                       57.0 ± 0%      57.0 ± 0%    ~     (all equal)
ManyMultiExpG1Reference-16                    177 ± 1%       177 ± 0%    ~     (p=1.000 n=5+4)
pkg:github.com/crate-crypto/go-ipa/bandersnatch/fr goos:linux goarch:amd64
ElementSetBytes-16                           0.00           0.00         ~     (all equal)
ElementMulByConstants/mulBy3-16              0.00           0.00         ~     (all equal)
ElementMulByConstants/mulBy5-16              0.00           0.00         ~     (all equal)
ElementMulByConstants/mulBy13-16             0.00           0.00         ~     (all equal)
ElementInverse-16                            0.00           0.00         ~     (all equal)
ElementButterfly-16                          0.00           0.00         ~     (all equal)
ElementExp-16                                0.00           0.00         ~     (all equal)
ElementDouble-16                             0.00           0.00         ~     (all equal)
ElementAdd-16                                0.00           0.00         ~     (all equal)
ElementSub-16                                0.00           0.00         ~     (all equal)
ElementNeg-16                                0.00           0.00         ~     (all equal)
ElementDiv-16                                0.00           0.00         ~     (all equal)
ElementFromMont-16                           0.00           0.00         ~     (all equal)
ElementToMont-16                             0.00           0.00         ~     (all equal)
ElementSquare-16                             0.00           0.00         ~     (all equal)
ElementSqrt-16                               0.00           0.00         ~     (all equal)
ElementMul-16                                0.00           0.00         ~     (all equal)
ElementCmp-16                                0.00           0.00         ~     (all equal)
pkg:github.com/crate-crypto/go-ipa/banderwagon goos:linux goarch:amd64
PrecompMSM/msm_length=1/precomp-16           0.00           0.00         ~     (all equal)
PrecompMSM/msm_length=2/precomp-16           0.00           0.00         ~     (all equal)
PrecompMSM/msm_length=4/precomp-16           0.00           0.00         ~     (all equal)
PrecompMSM/msm_length=8/precomp-16           0.00           0.00         ~     (all equal)
PrecompMSM/msm_length=16/precomp-16          0.00           0.00         ~     (all equal)
PrecompMSM/msm_length=32/precomp-16          0.00           0.00         ~     (all equal)
PrecompMSM/msm_length=64/precomp-16          0.00           0.00         ~     (all equal)
PrecompMSM/msm_length=128/precomp-16         0.00           0.00         ~     (all equal)
PrecompMSM/msm_length=256/precomp-16         0.00           0.00         ~     (all equal)
PrecompInitialize-16                         229k ± 0%      229k ± 0%    ~     (p=0.452 n=5+5)
```
