### PR TITLE
banderwagon: fix bytes uncompressed

### DIFF
--- a/banderwagon/element.go
+++ b/banderwagon/element.go
@@ -59,8 +59,10 @@ func (p Element) Bytes() [CompressedSize]byte {
 	return affineX.Bytes()
 }
 
-// BytesUncompressed returns the uncompressed serialized version of the element.
-func (p Element) BytesUncompressed() [UncompressedSize]byte {
+// BytesUncompressedTrusted returns the uncompressed serialized version of the element.
+// The returned bytes can only be used with SetBytesUncompressed with the trusted flag on.
+// This is because this method doesn't do any (x, y) transformation regarding the sign of y.
+func (p Element) BytesUncompressedTrusted() [UncompressedSize]byte {
 	// Convert underlying point to affine representation
 	var affine bandersnatch.PointAffine
 	affine.FromProj(&p.inner)


### PR DESCRIPTION
This PR fixes a situation found by @advaita-saha. 

The situation is that `BytesUncompressed()` returns serialized bytes in a "trusted" fashion -- that is, simply the X and Y coordinates to be deserialized later. That's fine, but in `SetBytesUncompressed(..., trusted bool)` we allow both trusted and untrusted deserialization. So if you call `SetBytesUncompressed(...)` with the wrong `trusted` flag then it will fail.

The reality is that we don't use uncompressed bytes serialization from untrusted sources in any place in geth (at least for now), so what I do here is to be a bit more clear about expectations in the API.

Concretely, rename to `BytesUncompressedTrusted()` which gives a clear signal that in the future those bytes can be deserialized with `SetBytesUncompressed(..., true)`.

I added a test that shows this case.