### PR TITLE
mod: update to gnark-crypto v0.13.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/crate-crypto/go-ipa
 go 1.18
 
 require (
-	github.com/consensys/gnark-crypto v0.12.1
+	github.com/consensys/gnark-crypto v0.13.0
 	github.com/leanovate/gopter v0.2.9
 	golang.org/x/sync v0.1.0
-	golang.org/x/sys v0.9.0
+	golang.org/x/sys v0.15.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/bits-and-blooms/bitset v1.7.0 h1:YjAGVd3XmtK9ktAbX8Zg2g2PwLIMjGREZJHl
 github.com/bits-and-blooms/bitset v1.7.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
-github.com/consensys/gnark-crypto v0.12.1 h1:lHH39WuuFgVHONRl3J0LRBtuYdQTumFSDtJF7HpyG8M=
-github.com/consensys/gnark-crypto v0.12.1/go.mod h1:v2Gy7L/4ZRosZ7Ivs+9SfUDr0f5UlG+EM5t7MPHiLuY=
+github.com/consensys/gnark-crypto v0.13.0 h1:VPULb/v6bbYELAPTDFINEVaMTTybV5GLxDdcjnS+4oc=
+github.com/consensys/gnark-crypto v0.13.0/go.mod h1:wKqwsieaKPThcFkHe0d0zMsbHEUWFmZcG7KBCse210o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
@@ -15,8 +15,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.9.0 h1:KS/R3tvhPqvJvwcKfnBHJwwthS11LRhmM5D59eEXa0s=
-golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 rsc.io/tmplfunc v0.0.3 h1:53XFQh69AfOa8Tw0Jm7t+GV7KZhOi6jzsCzTtKbMvzU=
 rsc.io/tmplfunc v0.0.3/go.mod h1:AG3sTPzElb1Io3Yg4voV9AGZJuleGAwaVRxL9M49PhA=


### PR DESCRIPTION
This PR updates to the latest `gnark-crypto@v0.13.0`.

I've run the set of benchmarks compared to master, and don't see any regressions or similar.
```
name                                     old time/op    new time/op    delta
pkg:github.com/crate-crypto/go-ipa goos:linux goarch:amd64
ProofGeneration/numopenings=2000-16        35.4ms ± 0%    34.5ms ± 0%   ~     (p=1.000 n=1+1)
ProofGeneration/numopenings=16000-16       56.0ms ± 0%    55.0ms ± 0%   ~     (p=1.000 n=1+1)
ProofGeneration/numopenings=32000-16       75.7ms ± 0%    74.4ms ± 0%   ~     (p=1.000 n=1+1)
ProofGeneration/numopenings=64000-16        117ms ± 0%     117ms ± 0%   ~     (p=1.000 n=1+1)
ProofGeneration/numopenings=128000-16       203ms ± 0%     215ms ± 0%   ~     (p=1.000 n=1+1)
ProofVerification/numopenings=2000-16      6.03ms ± 0%    5.76ms ± 0%   ~     (p=1.000 n=1+1)
ProofVerification/numopenings=16000-16     32.2ms ± 0%    31.0ms ± 0%   ~     (p=1.000 n=1+1)
ProofVerification/numopenings=32000-16     62.1ms ± 0%    60.0ms ± 0%   ~     (p=1.000 n=1+1)
ProofVerification/numopenings=64000-16      117ms ± 0%     111ms ± 0%   ~     (p=1.000 n=1+1)
ProofVerification/numopenings=128000-16     213ms ± 0%     208ms ± 0%   ~     (p=1.000 n=1+1)
pkg:github.com/crate-crypto/go-ipa/bandersnatch goos:linux goarch:amd64
MultiExpG1/32_points-16                     249µs ± 0%     249µs ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/64_points-16                     297µs ± 0%     272µs ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/128_points-16                    379µs ± 0%     381µs ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/256_points-16                    546µs ± 0%     545µs ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/512_points-16                    859µs ± 0%     859µs ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/1024_points-16                  1.29ms ± 0%    1.29ms ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/2048_points-16                  2.34ms ± 0%    2.33ms ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/4096_points-16                  4.09ms ± 0%    4.10ms ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/8192_points-16                  7.78ms ± 0%    7.76ms ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/16384_points-16                 14.7ms ± 0%    14.5ms ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/32768_points-16                 27.4ms ± 0%    27.5ms ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/65536_points-16                 49.9ms ± 0%    50.7ms ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/131072_points-16                93.2ms ± 0%    87.4ms ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/262144_points-16                 154ms ± 0%     156ms ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/524288_points-16                 305ms ± 0%     305ms ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/1048576_points-16                585ms ± 0%     579ms ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/2097152_points-16                1.14s ± 0%     1.15s ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/4194304_points-16                2.31s ± 0%     2.29s ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/8388608_points-16                4.90s ± 0%     4.95s ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/16777216_points-16               9.01s ± 0%     9.10s ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1Reference-16                      582ms ± 0%     609ms ± 0%   ~     (p=1.000 n=1+1)
ManyMultiExpG1Reference-16                  1.77s ± 0%     1.76s ± 0%   ~     (p=1.000 n=1+1)
pkg:github.com/crate-crypto/go-ipa/bandersnatch/fr goos:linux goarch:amd64
ElementSetBytes-16                         52.6ns ± 0%    53.9ns ± 0%   ~     (p=1.000 n=1+1)
ElementMulByConstants/mulBy3-16            5.16ns ± 0%    5.15ns ± 0%   ~     (p=1.000 n=1+1)
ElementMulByConstants/mulBy5-16            6.79ns ± 0%    6.81ns ± 0%   ~     (p=1.000 n=1+1)
ElementMulByConstants/mulBy13-16           10.2ns ± 0%    10.1ns ± 0%   ~     (p=1.000 n=1+1)
ElementInverse-16                          1.72µs ± 0%    1.76µs ± 0%   ~     (p=1.000 n=1+1)
ElementButterfly-16                        4.74ns ± 0%    4.72ns ± 0%   ~     (p=1.000 n=1+1)
ElementExp-16                              6.82µs ± 0%    6.91µs ± 0%   ~     (p=1.000 n=1+1)
ElementDouble-16                           3.40ns ± 0%    3.40ns ± 0%   ~     (p=1.000 n=1+1)
ElementAdd-16                              3.54ns ± 0%    3.56ns ± 0%   ~     (p=1.000 n=1+1)
ElementSub-16                              3.52ns ± 0%    3.54ns ± 0%   ~     (p=1.000 n=1+1)
ElementNeg-16                              2.34ns ± 0%    2.34ns ± 0%   ~     (p=1.000 n=1+1)
ElementDiv-16                              1.73µs ± 0%    1.71µs ± 0%   ~     (p=1.000 n=1+1)
ElementFromMont-16                         11.8ns ± 0%    11.9ns ± 0%   ~     (p=1.000 n=1+1)
ElementToMont-16                           16.1ns ± 0%    16.2ns ± 0%   ~     (p=1.000 n=1+1)
ElementSquare-16                           16.5ns ± 0%    16.5ns ± 0%   ~     (p=1.000 n=1+1)
ElementSqrt-16                             6.93µs ± 0%    6.88µs ± 0%   ~     (p=1.000 n=1+1)
ElementMul-16                              17.1ns ± 0%    17.1ns ± 0%   ~     (p=1.000 n=1+1)
ElementCmp-16                              27.0ns ± 0%    26.9ns ± 0%   ~     (p=1.000 n=1+1)
pkg:github.com/crate-crypto/go-ipa/banderwagon goos:linux goarch:amd64
PrecompMSM/msm_length=1/precomp-16         3.06µs ± 0%    3.09µs ± 0%   ~     (p=1.000 n=1+1)
PrecompMSM/msm_length=2/precomp-16         5.91µs ± 0%    5.94µs ± 0%   ~     (p=1.000 n=1+1)
PrecompMSM/msm_length=4/precomp-16         11.8µs ± 0%    11.8µs ± 0%   ~     (p=1.000 n=1+1)
PrecompMSM/msm_length=8/precomp-16         32.5µs ± 0%    32.2µs ± 0%   ~     (p=1.000 n=1+1)
PrecompMSM/msm_length=16/precomp-16        80.9µs ± 0%    81.2µs ± 0%   ~     (p=1.000 n=1+1)
PrecompMSM/msm_length=32/precomp-16         188µs ± 0%     187µs ± 0%   ~     (p=1.000 n=1+1)
PrecompMSM/msm_length=64/precomp-16         416µs ± 0%     415µs ± 0%   ~     (p=1.000 n=1+1)
PrecompMSM/msm_length=128/precomp-16        893µs ± 0%     887µs ± 0%   ~     (p=1.000 n=1+1)
PrecompMSM/msm_length=256/precomp-16       1.80ms ± 0%    1.81ms ± 0%   ~     (p=1.000 n=1+1)
PrecompInitialize-16                        343ms ± 0%     344ms ± 0%   ~     (p=1.000 n=1+1)

name                                     old alloc/op   new alloc/op   delta
pkg:github.com/crate-crypto/go-ipa goos:linux goarch:amd64
ProofGeneration/numopenings=2000-16        16.7MB ± 0%    16.5MB ± 0%   ~     (p=1.000 n=1+1)
ProofGeneration/numopenings=16000-16       41.6MB ± 0%    41.6MB ± 0%   ~     (p=1.000 n=1+1)
ProofGeneration/numopenings=32000-16       48.0MB ± 0%    48.0MB ± 0%   ~     (p=1.000 n=1+1)
ProofGeneration/numopenings=64000-16       59.5MB ± 0%    59.5MB ± 0%   ~     (p=1.000 n=1+1)
ProofGeneration/numopenings=128000-16      82.8MB ± 0%    82.8MB ± 0%   ~     (p=1.000 n=1+1)
ProofVerification/numopenings=2000-16      1.50MB ± 0%    1.50MB ± 0%   ~     (p=1.000 n=1+1)
ProofVerification/numopenings=16000-16     10.1MB ± 0%    10.1MB ± 0%   ~     (p=1.000 n=1+1)
ProofVerification/numopenings=32000-16     19.9MB ± 0%    19.9MB ± 0%   ~     (p=1.000 n=1+1)
ProofVerification/numopenings=64000-16     39.6MB ± 0%    39.6MB ± 0%   ~     (p=1.000 n=1+1)
ProofVerification/numopenings=128000-16    79.0MB ± 0%    79.0MB ± 0%   ~     (p=1.000 n=1+1)
pkg:github.com/crate-crypto/go-ipa/bandersnatch goos:linux goarch:amd64
MultiExpG1/32_points-16                    17.6kB ± 0%    17.6kB ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/64_points-16                    20.6kB ± 0%    20.6kB ± 0%   ~     (all equal)
MultiExpG1/128_points-16                   22.6kB ± 0%    22.6kB ± 0%   ~     (all equal)
MultiExpG1/256_points-16                   23.8kB ± 0%    23.8kB ± 0%   ~     (all equal)
MultiExpG1/512_points-16                   29.8kB ± 0%    29.8kB ± 0%   ~     (all equal)
MultiExpG1/1024_points-16                  44.5kB ± 0%    44.5kB ± 0%   ~     (all equal)
MultiExpG1/2048_points-16                  76.4kB ± 0%    76.4kB ± 0%   ~     (all equal)
MultiExpG1/4096_points-16                   142kB ± 0%     142kB ± 0%   ~     (all equal)
MultiExpG1/8192_points-16                   272kB ± 0%     272kB ± 0%   ~     (all equal)
MultiExpG1/16384_points-16                  533kB ± 0%     533kB ± 0%   ~     (all equal)
MultiExpG1/32768_points-16                 1.06MB ± 0%    1.06MB ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/65536_points-16                 2.11MB ± 0%    2.11MB ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/131072_points-16                4.20MB ± 0%    4.20MB ± 0%   ~     (all equal)
MultiExpG1/262144_points-16                8.40MB ± 0%    8.40MB ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/524288_points-16                16.8MB ± 0%    16.8MB ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/1048576_points-16               33.6MB ± 0%    33.6MB ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/2097152_points-16               67.1MB ± 0%    67.1MB ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/4194304_points-16                134MB ± 0%     134MB ± 0%   ~     (all equal)
MultiExpG1/8388608_points-16               1.48GB ± 0%    1.48GB ± 0%   ~     (all equal)
MultiExpG1/16777216_points-16              1.74GB ± 0%    1.74GB ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1Reference-16                     33.6MB ± 0%    33.6MB ± 0%   ~     (p=1.000 n=1+1)
ManyMultiExpG1Reference-16                  101MB ± 0%     101MB ± 0%   ~     (p=1.000 n=1+1)
pkg:github.com/crate-crypto/go-ipa/bandersnatch/fr goos:linux goarch:amd64
ElementSetBytes-16                          0.00B          0.00B        ~     (all equal)
ElementMulByConstants/mulBy3-16             0.00B          0.00B        ~     (all equal)
ElementMulByConstants/mulBy5-16             0.00B          0.00B        ~     (all equal)
ElementMulByConstants/mulBy13-16            0.00B          0.00B        ~     (all equal)
ElementInverse-16                           0.00B          0.00B        ~     (all equal)
ElementButterfly-16                         0.00B          0.00B        ~     (all equal)
ElementExp-16                               0.00B          0.00B        ~     (all equal)
ElementDouble-16                            0.00B          0.00B        ~     (all equal)
ElementAdd-16                               0.00B          0.00B        ~     (all equal)
ElementSub-16                               0.00B          0.00B        ~     (all equal)
ElementNeg-16                               0.00B          0.00B        ~     (all equal)
ElementDiv-16                               0.00B          0.00B        ~     (all equal)
ElementFromMont-16                          0.00B          0.00B        ~     (all equal)
ElementToMont-16                            0.00B          0.00B        ~     (all equal)
ElementSquare-16                            0.00B          0.00B        ~     (all equal)
ElementSqrt-16                              0.00B          0.00B        ~     (all equal)
ElementMul-16                               0.00B          0.00B        ~     (all equal)
ElementCmp-16                               0.00B          0.00B        ~     (all equal)
pkg:github.com/crate-crypto/go-ipa/banderwagon goos:linux goarch:amd64
PrecompMSM/msm_length=1/precomp-16          0.00B          0.00B        ~     (all equal)
PrecompMSM/msm_length=2/precomp-16          0.00B          0.00B        ~     (all equal)
PrecompMSM/msm_length=4/precomp-16          0.00B          0.00B        ~     (all equal)
PrecompMSM/msm_length=8/precomp-16          0.00B          0.00B        ~     (all equal)
PrecompMSM/msm_length=16/precomp-16         0.00B          0.00B        ~     (all equal)
PrecompMSM/msm_length=32/precomp-16         0.00B          0.00B        ~     (all equal)
PrecompMSM/msm_length=64/precomp-16         0.00B          0.00B        ~     (all equal)
PrecompMSM/msm_length=128/precomp-16        0.00B          0.00B        ~     (all equal)
PrecompMSM/msm_length=256/precomp-16        0.00B          0.00B        ~     (all equal)
PrecompInitialize-16                        833MB ± 0%     833MB ± 0%   ~     (p=1.000 n=1+1)

name                                     old allocs/op  new allocs/op  delta
pkg:github.com/crate-crypto/go-ipa goos:linux goarch:amd64
ProofGeneration/numopenings=2000-16         6.63k ± 0%     6.61k ± 0%   ~     (p=1.000 n=1+1)
ProofGeneration/numopenings=16000-16        9.06k ± 0%     9.06k ± 0%   ~     (p=1.000 n=1+1)
ProofGeneration/numopenings=32000-16        9.14k ± 0%     9.14k ± 0%   ~     (p=1.000 n=1+1)
ProofGeneration/numopenings=64000-16        9.15k ± 0%     9.15k ± 0%   ~     (p=1.000 n=1+1)
ProofGeneration/numopenings=128000-16       9.15k ± 0%     9.16k ± 0%   ~     (p=1.000 n=1+1)
ProofVerification/numopenings=2000-16       1.02k ± 0%     1.02k ± 0%   ~     (p=1.000 n=1+1)
ProofVerification/numopenings=16000-16      1.01k ± 0%     1.01k ± 0%   ~     (p=1.000 n=1+1)
ProofVerification/numopenings=32000-16      1.01k ± 0%     1.01k ± 0%   ~     (p=1.000 n=1+1)
ProofVerification/numopenings=64000-16      1.01k ± 0%     1.01k ± 0%   ~     (p=1.000 n=1+1)
ProofVerification/numopenings=128000-16     1.01k ± 0%     1.01k ± 0%   ~     (p=1.000 n=1+1)
pkg:github.com/crate-crypto/go-ipa/bandersnatch goos:linux goarch:amd64
MultiExpG1/32_points-16                      89.0 ± 0%      89.0 ± 0%   ~     (all equal)
MultiExpG1/64_points-16                       130 ± 0%       130 ± 0%   ~     (all equal)
MultiExpG1/128_points-16                      130 ± 0%       130 ± 0%   ~     (all equal)
MultiExpG1/256_points-16                      112 ± 0%       112 ± 0%   ~     (all equal)
MultiExpG1/512_points-16                      100 ± 0%       100 ± 0%   ~     (all equal)
MultiExpG1/1024_points-16                    89.0 ± 0%      89.0 ± 0%   ~     (all equal)
MultiExpG1/2048_points-16                    84.0 ± 0%      84.0 ± 0%   ~     (all equal)
MultiExpG1/4096_points-16                    84.0 ± 0%      84.0 ± 0%   ~     (all equal)
MultiExpG1/8192_points-16                    78.0 ± 0%      78.0 ± 0%   ~     (all equal)
MultiExpG1/16384_points-16                   74.0 ± 0%      74.0 ± 0%   ~     (all equal)
MultiExpG1/32768_points-16                   70.0 ± 0%      70.0 ± 0%   ~     (all equal)
MultiExpG1/65536_points-16                   66.0 ± 0%      66.0 ± 0%   ~     (all equal)
MultiExpG1/131072_points-16                  64.0 ± 0%      64.0 ± 0%   ~     (all equal)
MultiExpG1/262144_points-16                  62.0 ± 0%      62.0 ± 0%   ~     (all equal)
MultiExpG1/524288_points-16                  57.0 ± 0%      57.0 ± 0%   ~     (all equal)
MultiExpG1/1048576_points-16                 57.0 ± 0%      57.0 ± 0%   ~     (all equal)
MultiExpG1/2097152_points-16                 57.0 ± 0%      58.0 ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1/4194304_points-16                 93.0 ± 0%      93.0 ± 0%   ~     (all equal)
MultiExpG1/8388608_points-16                  107 ± 0%       107 ± 0%   ~     (all equal)
MultiExpG1/16777216_points-16                 107 ± 0%       108 ± 0%   ~     (p=1.000 n=1+1)
MultiExpG1Reference-16                       59.0 ± 0%      60.0 ± 0%   ~     (p=1.000 n=1+1)
ManyMultiExpG1Reference-16                    177 ± 0%       176 ± 0%   ~     (p=1.000 n=1+1)
pkg:github.com/crate-crypto/go-ipa/bandersnatch/fr goos:linux goarch:amd64
ElementSetBytes-16                           0.00           0.00        ~     (all equal)
ElementMulByConstants/mulBy3-16              0.00           0.00        ~     (all equal)
ElementMulByConstants/mulBy5-16              0.00           0.00        ~     (all equal)
ElementMulByConstants/mulBy13-16             0.00           0.00        ~     (all equal)
ElementInverse-16                            0.00           0.00        ~     (all equal)
ElementButterfly-16                          0.00           0.00        ~     (all equal)
ElementExp-16                                0.00           0.00        ~     (all equal)
ElementDouble-16                             0.00           0.00        ~     (all equal)
ElementAdd-16                                0.00           0.00        ~     (all equal)
ElementSub-16                                0.00           0.00        ~     (all equal)
ElementNeg-16                                0.00           0.00        ~     (all equal)
ElementDiv-16                                0.00           0.00        ~     (all equal)
ElementFromMont-16                           0.00           0.00        ~     (all equal)
ElementToMont-16                             0.00           0.00        ~     (all equal)
ElementSquare-16                             0.00           0.00        ~     (all equal)
ElementSqrt-16                               0.00           0.00        ~     (all equal)
ElementMul-16                                0.00           0.00        ~     (all equal)
ElementCmp-16                                0.00           0.00        ~     (all equal)
pkg:github.com/crate-crypto/go-ipa/banderwagon goos:linux goarch:amd64
PrecompMSM/msm_length=1/precomp-16           0.00           0.00        ~     (all equal)
PrecompMSM/msm_length=2/precomp-16           0.00           0.00        ~     (all equal)
PrecompMSM/msm_length=4/precomp-16           0.00           0.00        ~     (all equal)
PrecompMSM/msm_length=8/precomp-16           0.00           0.00        ~     (all equal)
PrecompMSM/msm_length=16/precomp-16          0.00           0.00        ~     (all equal)
PrecompMSM/msm_length=32/precomp-16          0.00           0.00        ~     (all equal)
PrecompMSM/msm_length=64/precomp-16          0.00           0.00        ~     (all equal)
PrecompMSM/msm_length=128/precomp-16         0.00           0.00        ~     (all equal)
PrecompMSM/msm_length=256/precomp-16         0.00           0.00        ~     (all equal)
PrecompInitialize-16                         229k ± 0%      229k ± 0%   ~     (p=1.000 n=1+1)

```